### PR TITLE
9017 크로스컨트리

### DIFF
--- a/김남주/17266_어두운굴다리
+++ b/김남주/17266_어두운굴다리
@@ -1,0 +1,35 @@
+#include <iostream>
+#include <algorithm>
+#include <queue>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+#define MAX 100'000
+
+int n,m,pos[MAX+2];
+
+bool check(const int& x) {
+    pos[0]=-x;
+    pos[m+1]=n+x;
+    for (int i=1;i<=m;i++) {
+        if (pos[i]-x>pos[i-1]+x) return false;
+        if (pos[i]+x<pos[i+1]-x) return false;
+    }
+    return true;
+}
+
+int main() {
+    fastio;
+    // read_input;
+    cin>>n>>m;
+    for (int i=1;i<=m;i++) cin>>pos[i];
+    int l=1,r=MAX;
+    while (l<=r) {
+        int mid=(l+r)/2;
+        if (check(mid)) r=mid-1;
+        else l=mid+1;
+    }
+    cout <<l;
+}

--- a/김남주/9017_크로스컨트리.cpp
+++ b/김남주/9017_크로스컨트리.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+int t,n;
+int a[1001],num[201],score[201],fif[201],cur_num[201];
+
+int main() {
+    fastio;
+    // read_input;
+    cin>>t;
+
+    while (t--) {
+        cin>>n;
+        memset(num,0,sizeof(num));
+        int t_n=0;
+        for (int i=1;i<=n;i++) {
+            cin>>a[i];
+            t_n=max(t_n,a[i]);  
+            num[a[i]]++;
+        }
+        for (int i=1;i<=t_n;i++) score[i]=0,fif[i]=0,cur_num[i]=0;
+        int x=0;
+        for (int i=1;i<=n;i++) {
+            if (num[a[i]]<6) continue;
+            ++x;
+            if (++cur_num[a[i]]<=4) score[a[i]]+=x;
+            if (cur_num[a[i]]==5) fif[a[i]]=x;
+        }
+
+        int min_score=1e9;
+        for (int i=1;i<=t_n;i++) {
+            if (num[i]<6) continue;
+            if (min_score<score[i]) {
+                min_score=score[i];
+            }
+            min_score=min(min_score,score[i]);
+            
+        }
+        int ans=0;
+        int min_fif=1e9;
+        for (int i=1;i<=t_n;i++) {
+            if (score[i]==min_score&&num[i]==6) {
+                if (fif[i]<min_fif) {
+                    min_fif=fif[i];
+                    ans=i;
+                }
+            }
+        }
+        cout<<ans<<'\n';
+    }
+}

--- a/김남주/9017_크로스컨트리.cpp
+++ b/김남주/9017_크로스컨트리.cpp
@@ -6,7 +6,7 @@
 using namespace std;
 
 int t,n;
-int a[1001],num[201],score[201],fif[201],cur_num[201];
+int a[1001],num[201],score[201],cur_num[201];
 
 int main() {
     fastio;
@@ -22,31 +22,23 @@ int main() {
             t_n=max(t_n,a[i]);  
             num[a[i]]++;
         }
-        for (int i=1;i<=t_n;i++) score[i]=0,fif[i]=0,cur_num[i]=0;
+        for (int i=1;i<=t_n;i++) score[i]=0,cur_num[i]=0;
         int x=0;
+        int min_score=1e9,min_fif=1e9;
+        int ans;
         for (int i=1;i<=n;i++) {
             if (num[a[i]]<6) continue;
             ++x;
             if (++cur_num[a[i]]<=4) score[a[i]]+=x;
-            if (cur_num[a[i]]==5) fif[a[i]]=x;
-        }
-
-        int min_score=1e9;
-        for (int i=1;i<=t_n;i++) {
-            if (num[i]<6) continue;
-            if (min_score<score[i]) {
-                min_score=score[i];
-            }
-            min_score=min(min_score,score[i]);
-            
-        }
-        int ans=0;
-        int min_fif=1e9;
-        for (int i=1;i<=t_n;i++) {
-            if (score[i]==min_score&&num[i]==6) {
-                if (fif[i]<min_fif) {
-                    min_fif=fif[i];
-                    ans=i;
+            if (cur_num[a[i]]==4) {
+                if (min_score>score[a[i]]) {
+                    min_score=score[a[i]];
+                    ans=a[i];
+                }
+            } else if (cur_num[a[i]]==5) {
+                if (min_score==score[a[i]] && min_fif>x) {
+                    min_fif=x;
+                    ans=a[i];
                 }
             }
         }


### PR DESCRIPTION
## 사고 흐름
문제를 읽자마자 구현문제라고 생각이 들었다.
문제의 조건과 예시 입력 두 가지를 보고 들어온 키 포인트는,
1. 들어온 팀이 차례대로 주어짐
2. 각 팀의 먼저 들어온 4명의 점수 합이 제일 작은 것을 출력하기

라는 생각이 들었음. 여기서 **n에 해당하는 반복문 하나 O(n)를 돌면서 점수를 합할 수 있다고 생각**했고 **사용해야 하는 자료구조는 배열로 충분하다고 생각함**
이제 배열에 어떤 정보를 저장해야 하는지, 반복문을 돌면서 어떤 정보에 접근해야 하는지 생각해야 함.

- 4명의 점수 합을 저장해야 함
  * 팀 마다 4명까지만 점수를 더해야 하므로 팀별로 현재 몇번째 선수를 체크하고 있는지도 저장해야함 (배열 필요)
- 먼저 5명 이하로 구성된 팀은 점수 산출에서 배제된다는 조건 -> **팀 전체 인원**을 체크해야 함
- 동점인 경우에 5번째 선수의 점수를 비교해봄 -> 다섯번째 선수의 점수를 저장해야 함

N(최대 1000) 사이즈의 배열 1개 
팀 개수 M(최대 200)의 사이즈의 배열을 총 4개 (팀 전체인원, 팀 점수, 5번째 점수, 순회 중 순서)을 선언하여 문제를 품

그러나 점수 산출에서 배제된 팀은 점수가 _N/A_ 로 취급된다는 즉, 점수 계산에서 배제된다는 조건을 놓침

해당 조건을 인지하고 푼 결과
1. 테스트 케이스가 있는 문제이므로 테스트 케이스마다 배열(num,score,fif,cur_num) 0으로 초기화
2. 팀 전체 인원 계산 및 팀 전체 수 계산 : O(N)
3. 팀별 점수 계산 (4번 선수까지의 점수 합, 5번째 선수의 점수): O(N)
4. 최소 점수 계산: O(M)
5. 동점자는 5번째 선수 점수 비교: O(M)

## 복기
### 구현 문제를 대할 때의 태도
1. 필요한 조건을 리스팅 하기 -> 그래야 위 같이 조건을 안 놓침(종이, 펜으로) 
2.  시간복잡도 생각
* 테스트 케이스 2000개, n은 최대 1000. -> 2000*1000=2백만. 대충 1억이 1초라고 생각했을때 n^2은 통과 어렵다고 생각됨, -> o(n)으로 풀기
3. 위에서 생각한 시간복잡도 안에 풀 수 있는 방식으로 구현을 위한 자료 구조 생각 (배열, 그래프, 트리? 메모리는 초과하지 않는가?)
### 최적화
입력이 들어온 순서대로 주어진다는 특성을 이용해서 4,5번 계산을 3번에서 한번에 계산하여 중복 계산을 피할 수 있음 -> 9017-2 커밋에 수정
