### PR TITLE
13305 주유소

### DIFF
--- a/박민수/13305_주유소.java
+++ b/박민수/13305_주유소.java
@@ -1,0 +1,49 @@
+package SoraeCodingMasters.BOJ13305;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 13305번
+ * 주유소
+ * 2024-02-08
+ * 시간 제한 : 2초
+ * 메모리 제한 : 512MB
+ */
+
+public class Main {
+    static int N; // 2 <= N <= 100,000 -> 최소 NlogN
+    static int[] distances;
+    static int[] prices;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        N = Integer.parseInt(br.readLine());
+        distances = new int [N - 1];
+        prices = new int [N];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N - 1; i++) {
+            distances[i] = Integer.parseInt(st.nextToken());
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            prices[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int minPrice = Integer.MAX_VALUE;
+        long totalPrice = 0;
+        for (int i = 0; i < N - 1; i++) {
+            if (minPrice > prices[i]) {
+                minPrice = prices[i];
+            }
+            totalPrice += (long) minPrice * distances[i];
+        }
+
+        System.out.println(totalPrice);
+    }
+
+}


### PR DESCRIPTION
# BOJ 13305\_주유소

## 사고 흐름

가장 먼저 입력의 크기와 시간 제한을 확인하였다.

### 입력

- 도시의 개수 N (2 <= N <= 100,000)
- 도로의 길이 개수 N - 1 (1 <= 도로의 길이 총 합 <= 1,000,000,000)
- 주유소의 리터당 가격 (1 <= 리터당 가격 <= 1,000,000,000)
- 
시간 제한이 2초이기 때문에 O(NlogN) 까지는 괜찮다고 생각하였다.

각 도시를 순회할 때 **주유소의 리터당 가격 최소값을 갱신**해나가면서 최소 비용을 구해야겠다고 생각하였다.

또한 주유소의 리터당 가격이 최대 10억이기 때문에 최종 비용을 `int`타입으로 선언하게 되면 overflow가 발생할 것 같아서 `long` 타입으로 선언하였다.

### 시간 복잡도

1. 주유소의 리터당 가격 최소값을 갱신 + 총 비용 구하기: O(N)

## 복기
각 도시를 지나면서 최적의 결정(현 상황에서 가장 가격이 싼 주유소)을 한다는 점에서 그리디 알고리즘으로 접근해야겠다는 생각을 해야할 것 같다.

## 비슷한 문제