### PR TITLE
20920 영단어 암기

### DIFF
--- a/김남주/20920_영단어암기.cpp
+++ b/김남주/20920_영단어암기.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <string>
-#include <unordered_map>
+#include <vector>
 #include <algorithm>
 using namespace std;
 
@@ -8,9 +8,6 @@ using namespace std;
 #define read_input freopen("input.txt","r",stdin);
 
 #define MAX 100'000
-unordered_map<string, int> map;
-string word[MAX];
-int w_n = 0;
 
 int main() {
 	fastio;
@@ -18,20 +15,23 @@ int main() {
 	int n, m;
 	cin >> n >> m;
 	string tmp;
-	for (int i = 0;i < n; i++) {
-		cin >> tmp;
-		if (tmp.size() < m) continue;
-		if (map[tmp]++ == 0) word[w_n++] = tmp;
-	}
-	int a_n, b_n;
-	sort(word, word + w_n, [&](const string& a, const string& b) {
-		a_n = map[a], b_n = map[b];
-		if (a_n > b_n) return true;
-		else if (a_n == b_n) {
-			if (a.size() > b.size()) return true;
-			if (a.size() == b.size()) return a < b;
-		}
+	vector<string> word(n);
+	for (auto& i : word) cin >> i;
+	sort(word.begin(), word.end(), [&](const string& a, const string& b) {
+		if (a.size() > b.size()) return true;
+		if (a.size() == b.size()) return a < b;
 		return false;
 	});
-	for (int i = 0;i < w_n;i++) cout << word[i] << '\n';
+	vector<pair<int, int>> ans;
+	for (int i = 0;i < n;i++) {
+		if (word[i].size() < m) break;
+		int num = 0;
+		while (i < n-1 && word[i] == word[i + 1]) {
+			num++;
+			i++;
+		}
+		ans.push_back({ -num,i });
+	}
+	sort(ans.begin(), ans.end());
+	for (auto& [_, idx] : ans) cout << word[idx] << '\n';
 }

--- a/김남주/20920_영단어암기.cpp
+++ b/김남주/20920_영단어암기.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <algorithm>
+using namespace std;
+
+#define fastio cin.tie(0),cout.tie(0),ios::sync_with_stdio(false);
+#define read_input freopen("input.txt","r",stdin);
+
+#define MAX 100'000
+unordered_map<string, int> map;
+string word[MAX];
+int w_n = 0;
+
+int main() {
+	fastio;
+	//read_input;
+	int n, m;
+	cin >> n >> m;
+	string tmp;
+	for (int i = 0;i < n; i++) {
+		cin >> tmp;
+		if (tmp.size() < m) continue;
+		if (map[tmp]++ == 0) word[w_n++] = tmp;
+	}
+	int a_n, b_n;
+	sort(word, word + w_n, [&](const string& a, const string& b) {
+		a_n = map[a], b_n = map[b];
+		if (a_n > b_n) return true;
+		else if (a_n == b_n) {
+			if (a.size() > b.size()) return true;
+			if (a.size() == b.size()) return a < b;
+		}
+		return false;
+	});
+	for (int i = 0;i < w_n;i++) cout << word[i] << '\n';
+}


### PR DESCRIPTION
## 사고 흐름
단어가 무작위 순서대로 주어지고 다음과 같은 순서로 출력해야 함
1. 많이 등장한 단어
2. 크기가 큰 단어
3. 사전순

1을 체크하기 위해 단어의 개수를 카운팅 해야됨. 따라서 **해쉬맵 자료구조를 사용해야 된다고 판단** (중복으로 입력된 단어의 등장 횟수를 1씩 증가시켜야 하므로)
그 후에 1,2,3 순서에 따라 정렬해줘야 됨. 이는 sort에 람다함수를 넘겨서 구현해주면 됨

## 복기
### 최적화 (C++ 한정일 수도 있음)
**해쉬맵(unordered_map)을 사용했을때 메모리를 많이 사용하고, 특히 string 타입의 hash로 접근했을 때 시간복잡도는 O(1)이지만 느린 연산이므로 input size 가 크면 시간이 오래 걸림.**
1. 따라서 먼저 단어를 모두 입력받은 후에 (중복체크 하지 않고) 2,3번 순으로 먼저 정렬.
  * 이렇게 되면 같은 단어는 배열 내에서 연속되어 존재함.
2. 새로운 배열을 선언하고, O(N) 순회 하면서 같은 단어에 대해 count를 세어 단어의 인덱스와 함께 새로운 배열에 저장. 
3. count를 기준으로 내림차순 정렬
  * 2, 3에 따른 기준에 대해서는 그대로 정렬되어 있는 상태를 유지한 채로 단어가 많이 등장한 횟수에 따라 정렬이 됨.

commit 20920-2에 반영
