### PR TITLE
2512 예산

### DIFF
--- a/박민수/2512_예산.java
+++ b/박민수/2512_예산.java
@@ -1,0 +1,68 @@
+package SoraeCodingMasters.BOJ2512;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 2512번
+ * 예산
+ * 2024-02-09
+ * 시간 제한 : 1초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int N; // 3 <= N <= 10,000
+    static int[] request;
+    static int[] budget;
+    static int M; // N <= M <= 100,000
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        request = new int[N];
+        int maxRequest = Integer.MIN_VALUE;
+        for (int i = 0; i < N; i++) {
+            request[i] = Integer.parseInt(st.nextToken());
+            maxRequest = Math.max(maxRequest, request[i]);
+        }
+
+        M = Integer.parseInt(br.readLine());
+
+        int fix = binarySearch(1, maxRequest);
+
+        System.out.println(fix);
+    }
+
+    public static int binarySearch(int left, int right) {
+        int result = 0;
+
+        while(left <= right) {
+            int mid = (left + right) / 2;
+
+            if (!calculateBudget(mid)) {
+                // 예산 부족
+                left = mid + 1;
+                result = mid;
+            } else {
+                // 예산 초과
+                right = mid - 1;
+            }
+        }
+
+        return result;
+    }
+
+    public static boolean calculateBudget(int mid) {
+        int total = 0;
+
+        for (int i = 0; i < N; i++) {
+            total += Math.min(mid, request[i]);
+        }
+
+        return total > M;
+    }
+}


### PR DESCRIPTION
# BOJ 2512\_예산

## 사고 흐름

가장 먼저 입력의 크기와 시간 제한을 확인하였다.

### 입력

- 지방의 수 N (3 <= N <= 10,000)
- 지방의 예산 요청 B(1 <= 지방의 예상 요청 <= 100,000)
- 총 예산 M (1 <= M <= 1,000,000,000)

문제를 보고 이전에 풀었던 [백준 17266번 어두운 굴다리](https://www.acmicpc.net/problem/17266)와 비슷한 문제라고 생각했다.

따라서 이분 탐색의 범위를 1 부터 예상 요청의 최댓값으로 정하고 `calculateBudget` 함수로 판별하여 예산을 구해야겠다는 생각을 했다.

### 시간 복잡도

1. 이분 탐색 : O(logB)
2. `calculateBudget` 판별 함수: O(N)

## 복기
이런 유형의 문제를 파라매트릭 서치(Parametric Search)라고 하는 것을 알게 되었다.

파라메트릭 서치 → 주어진 문제를 **결정문제로 변형**하여 **이분탐색을 통해 해결**하는 것

![image](https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/75938496/01f20fa0-007f-4222-9b52-0ae4c3b63722)


위 그림 같은 방법으로 도식화하여 **가능한(특정 조건을 만족하는) 최대 or 최소의 값 구하기 문제**에 잘 적용을 해야겠다.