### PR TITLE
21921 블로그

### DIFF
--- a/박민수/1515_수이어쓰기.java
+++ b/박민수/1515_수이어쓰기.java
@@ -1,0 +1,35 @@
+package SoraeCodingMasters.BOJ1515;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/***
+ * 백준 1515번
+ * 수 이어 쓰기
+ * 2024-02-11
+ * 시간 제한 : 2초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static String target;
+    static int pointer = 0;
+    static int N = 1;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        target = br.readLine();
+
+        while (pointer < target.length()) {
+            String s = String.valueOf(N++);
+
+            for (int i = 0; i < s.length(); i++) {
+                if (s.charAt(i) == target.charAt(pointer)) pointer++;
+            }
+
+            if (pointer >= target.length()) break;
+        }
+
+        System.out.println(N - 1);
+    }
+}

--- a/박민수/21921_블로그.java
+++ b/박민수/21921_블로그.java
@@ -16,35 +16,29 @@ import java.util.StringTokenizer;
 public class Main {
     static int X, N; // 1 <= X <= N <= 250,000
     static int[] visitors;
-    static int[] dp;
+
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringTokenizer st = new StringTokenizer(br.readLine());
         N = Integer.parseInt(st.nextToken());
         X = Integer.parseInt(st.nextToken());
 
-        visitors = new int[N];
+        visitors = new int[N + 1];
         st = new StringTokenizer(br.readLine());
-        for (int i = 0; i < N; i++) {
-            visitors[i] = Integer.parseInt(st.nextToken());
-        }
 
-        dp = new int[N];
-        for (int i = 0; i < X; i++) {
-            dp[0] += visitors[i];
-        }
-
-        for(int i = 1; i <= N - X; i++) {
-            dp[i] = dp[i - 1] + visitors[i + X - 1] - visitors[i - 1];
+        // 누적 합
+        for (int i = 1; i <= N; i++) {
+            visitors[i] = visitors[i - 1] + Integer.parseInt(st.nextToken());
         }
 
         int count = 0;
         int maxVisitor = Integer.MIN_VALUE;
-        for (int i = 0; i < dp.length; i++) {
-            if (maxVisitor < dp[i]) {
-                maxVisitor = dp[i];
+        for (int i = 0; i <= N - X; i++) {
+            int distance = visitors[i + X] - visitors[i];
+            if (maxVisitor < distance) {
+                maxVisitor = distance;
                 count = 1;
-            } else if (maxVisitor == dp[i]) {
+            } else if (maxVisitor == distance) {
                 count++;
             }
         }

--- a/박민수/21921_블로그.java
+++ b/박민수/21921_블로그.java
@@ -1,0 +1,59 @@
+package SoraeCodingMasters.BOJ21921;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 21921번
+ * 블로그
+ * 2024-02-11
+ * 시간 제한 : 1초
+ * 메모리 제한 : 512MB
+ */
+
+public class Main {
+    static int X, N; // 1 <= X <= N <= 250,000
+    static int[] visitors;
+    static int[] dp;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        X = Integer.parseInt(st.nextToken());
+
+        visitors = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            visitors[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dp = new int[N];
+        for (int i = 0; i < X; i++) {
+            dp[0] += visitors[i];
+        }
+
+        for(int i = 1; i <= N - X; i++) {
+            dp[i] = dp[i - 1] + visitors[i + X - 1] - visitors[i - 1];
+        }
+
+        int count = 0;
+        int maxVisitor = Integer.MIN_VALUE;
+        for (int i = 0; i < dp.length; i++) {
+            if (maxVisitor < dp[i]) {
+                maxVisitor = dp[i];
+                count = 1;
+            } else if (maxVisitor == dp[i]) {
+                count++;
+            }
+        }
+
+        if (maxVisitor == 0) {
+            System.out.println("SAD");
+        } else {
+            System.out.println(maxVisitor + "\n" + count);
+        }
+    }
+
+}


### PR DESCRIPTION
# BOJ 21921\_블로그

## 사고 흐름

가장 먼저 입력의 크기와 시간 제한을 확인하였다.

### 입력

- 블로그 시작하고 지난 일수 N
- 기간 X(1 <= X <= N <= 250,000)
- 방문자 수 M (1 <= M <= 8,000)

기간 동안의 총 방문자 수를 구할 때 하나씩 더해서 구하는 것은 반복문을 두번 돌아야하기 때문에 비효율적이라고 생각하였다.

따라서, DP 방식으로 이미 계산한 구간의 값을 이용하여 다음과 같이 구해야겠다고 생각했다.

![image](https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/75938496/94f165f4-8795-493f-8072-1ad9cbc53ee9)


### 시간 복잡도

1. dp 테이블 만들기 : O(N)
2. 최대값 구하기 : O(N)

## 복기

이 문제를 풀고나서 알게 되었는데, 이 문제는 슬라이딩 윈도우 알고리즘과 누적 합 알고리즘으로 풀 수 있었다.

처음 풀었던 방식은 두 알고리즘 중 슬라이딩 윈도우 알고리즘과 유사한 방식으로 접근하여 DP 테이블을 선언하고 풀었지만, 변수 하나로도 충분히 계산할 수 있기 때문에 따로 `dp` 배열을 선언할 필요는 없었다. 

구간의 합을 구하는 문제를 만나게 된다면 슬라이딩 윈도우 알고리즘과 누적 합 알고리즘을 생각할 수 있어야겠다.

# BOJ 1515\_수 이어 쓰기

## 사고 흐름

처음에 이 문제를 이해하고 접근한 방법은 다음과 같다.

1. 이어붙인 수의 문자를 하나씩 읽고 가능한 수 N을 문자열로 만들어 비교한다.
   1. 가능한 수에 해당 문자가 하나라도 존재하면, 이어붙인 수의 다음 문자를 읽는다.
   2. 가능한 수에 해당 문자가 존재하지 않으면, 가능한 수를 +1 증가시킨다.
2. 1번의 과정을 이어붙인 수를 다 읽을 때 까지 반복한다.

그러나, 이 방법은 이어붙인 수와 가능한 수가 한개 이상 일치할 경우를 고려하지 않았다.

## 복기

솔직히 문제를 읽고서 이해가 안됐었다. 맘에 드는 숫자가 1이어서 이어붙인 수에 있는 모든 1을 지웠다는건지, 랜덤으로 숫자를 지웠다는건지 헷갈렸다.

예제를 통해서 이런 조건을 알아야 한다는게 조금 어렵게 느껴졌고 조건을 캐치하는 능력을 키워야겠다는 생각이 들었다.

또한, 내가 작성한 코드에서 Index 에러가 떴는데 이 부분도 꼼꼼하게 고려해야할 것 같다.
