### PR TITLE
19941 햄버거 분배 & 17484 진우의 달 여행(Small)

### DIFF
--- a/박민수/17484_진우의달여행(Small).java
+++ b/박민수/17484_진우의달여행(Small).java
@@ -1,0 +1,73 @@
+package SoraeCodingMasters.BOJ17484;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 17484번
+ * 진우의 달 여행(Small)
+ * 2024-02-13
+ * 시간 제한 : 1초
+ * 메모리 제한 : 256MB
+ */
+
+public class Main {
+    static final int MAX_VALUE = 1000;
+    static int N, M; // 2 <= N, M <= 6
+    static int[][] map;
+    static int[][][] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        map = new int[N][M];
+        dp = new int[N][M][3];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+
+                // init dp
+                if (i == 0) {
+                    Arrays.fill(dp[i][j], map[i][j]);
+                }
+            }
+        }
+
+
+        for (int i = 1; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (j == 0) {
+                    dp[i][j][0] = MAX_VALUE;
+                    dp[i][j][1] = map[i][j] + dp[i - 1][j][2];
+                    dp[i][j][2] = map[i][j] + Math.min(dp[i - 1][j + 1][0], dp[i - 1][j + 1][1]);
+                } else if (j >= 1 && j < M - 1) {
+                    dp[i][j][0] = map[i][j] + Math.min(dp[i - 1][j - 1][1], dp[i - 1][j - 1][2]);
+                    dp[i][j][1] = map[i][j] + Math.min(dp[i - 1][j][0], dp[i - 1][j][2]);
+                    dp[i][j][2] = map[i][j] + Math.min(dp[i - 1][j + 1][0], dp[i - 1][j + 1][1]);
+                } else {
+                    dp[i][j][0] = map[i][j] + Math.min(dp[i - 1][j - 1][1], dp[i - 1][j - 1][2]);
+                    dp[i][j][1] = map[i][j] + dp[i - 1][j][0];
+                    dp[i][j][2] = MAX_VALUE;
+                }
+            }
+        }
+
+        int answer = Integer.MAX_VALUE;
+        for (int i = 0; i < M; i++) {
+            for (int j = 0; j < 3; j++) {
+                answer = Math.min(answer, dp[N - 1][i][j]);
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+}

--- a/박민수/19941_햄버거분배.java
+++ b/박민수/19941_햄버거분배.java
@@ -1,0 +1,46 @@
+package SoraeCodingMasters.BOJ19941;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 19941번
+ * 햄버거 분배
+ * 2024-02-12
+ * 시간 제한 : 0.5초
+ * 메모리 제한 : 256MB
+ */
+
+public class Main {
+    static int N; // 1 <= N <= 20,000
+    static int K; // 1 <= K <= 10
+    static char[] input;
+    static int count = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        input = br.readLine().toCharArray();
+
+        for (int i = 0; i < N; i++) {
+            if (input[i] == 'H') {
+                // check left first right second
+                for (int j = i - K; j <= i + K; j++) {
+                    if ((j >= 0 && j < N) && input[j] == 'P') {
+                        count++;
+                        input[j] = 'X';
+                        break;
+                    }
+                }
+            }
+        }
+
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
# BOJ 19941\_햄버거 분배

## 사고 흐름

가장 먼저 입력의 크기와 시간 제한을 확인하였다.

### 입력

- 식탁의 길이 N (1 <= N <= 20,000)
- 햄버거를 선택할 수 있는 길이 K (1 <= K <= 10)

사람과 햄버거의 위치 정보가 담긴 문자열을 하나씩 읽어가면서 '햄버거'를 만나게 될 때, '해당 햄버거를 기준으로 K 범위 내 가장 왼쪽에 위치한 사람'부터 선택해야 된다고 생각하였다.

### 시간 복잡도

1. 식탁 탐색 : O(N)
2. 범위 탐색 : O(K)

## 복기

해당 문제가 그리디 알고리즘으로 접근할 수 있는지 판단하기 위해 다음 두 가지 조건을 확인해야한다.

### 최적 부분 구조 (optimal substructure)
주어진 문제 P에 대한 **최적의 솔루션이 P의 부분 문제들의 최적의 솔루션으로으로 구성**될 경우, 문제 P가 최적의 부분 구조를 갖는다고 할 수 있다.

### 그리디 선택 (Greedy Choice)
주어진 문제 P에 대한 **지역적 최적 솔루션을 반복적으로 선택하여 전체 최적 솔루션을 구할 수 있을 경우**, 문제 P가 그리디 선택 속성을 갖는다고 할 수 있다.

# BOJ 17484 진우의 달 여행(Small)

## 사고 흐름

가장 먼저 입력의 크기와 시간 제한을 확인하였다.

입력이 적어서 완전 탐색으로 풀 수 있을 것이라고 생각했지만, DP로도 풀 수 있을 것 같아서 DP로 도전해보았다.

같은 방향으로 두 번 움직일 수 없다는 조건을 어떻게 처리해야하는지 떠오르지가 않았다.

결론은 DP 테이블을 3차원 배열을 사용하여 방향 정보를 기억하여 해결할 수 있다.

## 복기

DP 테이블에 어떤 정보를 담을 것인지 신중하게 정해야할 것 같다.