### PR TITLE
17484 진우의 달 여행 (small)

### DIFF
--- a/김남주/17484_진우의달여행(small).cpp
+++ b/김남주/17484_진우의달여행(small).cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+#define MAX 6
+
+int dx[3]{ -1,0,1 };
+
+int main() {
+	fastio;
+	//read_input;
+	int n, m;
+	cin >> n >> m;
+	int g[MAX][MAX];
+	for (int i = 0;i < n;i++) for (int j = 0;j < m;j++) cin >> g[i][j];
+	int dp[MAX+1][MAX][3];
+	int INF = 987654321;
+	for (int j = 0;j < m;j++)dp[0][j][0] = dp[0][j][1] = dp[0][j][2] = 0;
+	for (int i = 1;i <= n;i++) {
+		for (int j = 0;j < m;j++) {
+			dp[i][j][0] = dp[i][j][1] = dp[i][j][2] = INF;
+			for (int d = 0;d < 3;d++) {
+				if (j + dx[d] < 0 || j + dx[d] >= m) continue;
+				for (int x = 0;x < 3;x++) {
+					if (d == x)continue;
+					dp[i][j][d] = min(dp[i][j][d], dp[i-1][j + dx[d]][x] + g[i - 1][j]);
+				}
+			}
+		}
+	}
+	int ans = INF;
+	for (int j = 0;j < m;j++) for (int k = 0;k < 3;k++) ans = min(ans, dp[n][j][k]);
+	cout << ans;
+}


### PR DESCRIPTION
## 사고 흐름
전형적인 DP 문제처럼 느껴졌으나 입력의 크기가 작으므로 브루트포스로도 풀 수 있음
그러나 (large)버전의 문제에는 DP로만 풀이가 가능할 것이므로 DP로 풀었다.
어떤 상태를 DP 테이블로 정의하느냐가 중요.
어떤 중복되는 경우를 체크해야 할까? 
이전에 온 경로를 그대로 다시 갈 수 없으므로 이전 경로에 따른 가능한 결과가 달라질 것임을 알고 DP 테이블을 다음과 같은 3차원으로 선언해야 함. -> **(현재 행, 현재 열, 이전에 온 경로)**에 따른 **현재 위치(행,열)에서의 최솟값**

## 복기
여기서 메모리 사용량을 최적화 할 수 있는데 (small) 버전은 최적화를 하나 하지 않으나 큰 차이가 없지만 (large [https://www.acmicpc.net/problem/17485](url)) 버전은 매우 크다.
bottom-up방식으로 DP테이블을 갱신해 나갈때 필요한 정보는 이전 행의 정보만 필요하므로 DP[2][열][3] 으로 선언하고 for 문에서 % 연산자를 통해 이전의 정보에만 접근할 수 있다.
즉, 최대 1000으로 선언해야 할 dp 테이블을 2로 줄일 수 있다.

또한 입력을 미리 선언한 1000 x 1000 배열에 저장하지 않고 그때 그때 입력을 받아서 DP 테이블을 갱신하는 것이 가능하므로 메모리를 크게 최적화 가능

```cpp
int dp[2][MAX][3]; // 이전의 정보만 필요하므로 2로 선언
	int INF = 987654321;
	int cur;
	for (int j = 0;j < m;j++)dp[0][j][0] = dp[0][j][1] = dp[0][j][2] = 0;
	for (int i = 1;i <= n;i++) {
		for (int j = 0;j < m;j++) {
			cin >> cur; // 미리 입력을 저장하지 않고 그때 그때 값을 입력 받아 사용
			dp[i%2][j][0] = dp[i%2][j][1] = dp[i%2][j][2] = INF;
			for (int d = 0;d < 3;d++) {
				if (j + dx[d] < 0 || j + dx[d] >= m) continue;
				for (int x = 0;x < 3;x++) {
					if (d == x)continue;
					dp[i%2][j][d] = min(dp[i%2][j][d], dp[(i+1)%2][j + dx[d]][x] + cur);
				}
			}
		}
	}
```