### PR TITLE
2607 비슷한 단어 & 3758 KCPC

### DIFF
--- a/김남주/2607_비슷한단어.cpp
+++ b/김남주/2607_비슷한단어.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+int x[26];
+int k[26];
+
+
+int main() {
+	fastio;
+	//read_input;
+
+	int n;
+	cin >> n;
+	string s;
+	cin >> s;
+	for (auto& c : s) x[c - 'A']++;
+	int ans = 0;
+	for (int i = 1;i < n;i++) {
+		for (int j = 0;j < 26;j++) k[j] = 0;
+		cin >> s;
+		for (auto& c : s) k[c - 'A']++;
+		int ldiff = 0, mdiff = 0;
+		for (int j = 0;j < 26;j++) x[j] - k[j] < 0 ? ldiff += (-x[j] + k[j]) : mdiff += (x[j] - k[j]);
+		if (ldiff + mdiff <= 1)ans++;
+		else if (mdiff == 1 && ldiff == 1)ans++;
+	}
+	cout << ans;
+}

--- a/김남주/3758_KCPC.cpp
+++ b/김남주/3758_KCPC.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <unordered_map>
+#include <string>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+// 최종점수 -> 점수의 합 -> 각 문제의 점수: 최고점
+// 풀이 제출 횟수
+// 마지막 제출 시간
+
+int T,n, k, t,m;
+int record[100][103];
+int result[100];
+
+int main() {
+	fastio;
+	//read_input;
+
+	cin >> T;
+	int i, j, s;
+	while (T--) {
+		cin >> n >> k >> t >> m;
+		for (int tmp = 0;tmp < n;tmp++) {
+			for (int tmp2 = 0;tmp2 < k;tmp2++) record[tmp][tmp2] = 0;
+			record[tmp][100] = record[tmp][101] = record[tmp][102] = 0;
+			result[tmp] = tmp;
+		}
+		for (int q = 0;q < m;q++) {
+			cin >> i >> j >> s;
+			record[i - 1][101]++;
+			record[i - 1][102] = q;
+			if (record[i - 1][j - 1] < s) {
+				record[i - 1][100] = record[i - 1][100] - record[i - 1][j - 1] + s;
+				record[i - 1][j - 1] = s;
+			}
+		}
+		sort(result, result + n, [](int& a, int& b) {
+			if (record[a][100] > record[b][100]) return true;
+			if (record[a][100] == record[b][100]) {
+				if (record[a][101] < record[b][101]) return true;
+				if (record[a][101] == record[b][101]) {
+					return record[a][102] < record[b][102];
+				}
+			}
+			return false;
+		});
+		int ans = 0;
+		for (;ans < n;ans++)if (result[ans] == t - 1)break;
+		cout << ans + 1<<'\n';
+	}
+}


### PR DESCRIPTION
# 2607 비슷한 단어
## 사고 흐름
입력된 알파벳의 개수에 따라 문제에서 요구하는 비슷한 단어 판별이 가능하므로 이를 저장할 자료구조가 필요 -> hash

알파벳의 개수가 26이므로 26사이즈의 배열을 선언하면 된다.

그 후 비슷한 단어에는 조건이 3개 있는데
1. 모든 알파벳 개수가 동일
2. 하나의 알파벳을 더하거나 빼서 1번을 만족하는 경우
3. 하나의 알파벳을 바꿔서 1번을 만족하는 경우

1번과 2번의 경우에는 단순히 알파벳 개수의 차이를 더해서 1 이하이면 만족.
3번의 경우에는 (많은 알파벳의 개수)== 1 && (적은 알파벳의 개수) == 1 이면 만족
따라서 ldiff (적은 알파벳 개수), mdiff (많은 알파벳 개수)를 선언하여 `ldiff+mdiff<=1 || (mdiff==1&&ldiff==1)`를 판별

## 복기
그러나 더 최적화 할 수 있는 부분이 있었음.
1. 입력받은 문자열의 길이가 첫번째 단어의 길이보다 2 이상 크면 비슷한 단어가 아님을 확정하고 위의 step에 따라 검사할 필요가 없음 
2. 3번의 경우 굳이 ldiff, mdiff를 나누지 않고 단순 diff만을 계산한 뒤에 ( 문자열의 길이가 같다 && diff==2 ) 조건으로도 파악 가능 


문자열을 다루는 문제에서는 문자열의 크기를 활용할 수 있음을 알면 좋을 것 같다.


---
# 3758 KCPC
## 사고 흐름
문제를 읽으면서 주어진 조건 3개에 따라 정렬을 해야할 것 같다는 생각이 들었다.
입력으로 주어지는 데이터를 어떤 자료구조에 저장할 것인지 이제 생각해야 한다.
1. 각 문제의 최종점수의 합 (최종 점수는 제출한 점수 중에 가장 큰 점수)
2. 제출 횟수
3. 제출한 마지막 시간

3가지의 정보를 저장해야 한다.
2,3번 정보는 반복문을 돌면서 쉽게 업데이트 할 수 있고, 1번 정보는 각 제출마다 문제의 최고 점수를 비교하는 과정이 필요하므로 문제마다 최고 점수를 그때 그때 업데이트 해야 한다.

따라서, 팀 별로 1,2,3번을 저장할 수 있게 (팀 개수) * (103 (문제 최대100개 + 1,2,3번 정보))의 크기의 2차원 배열을 정적으로 선언

그리고 입력으로 주어진 팀이 몇 등 했는지를 파악해야 하므로 argsort 방식으로 정렬.
-> result의 인덱스 접근은 등수 접근된 원소는 팀 id를 나타낼 수 있도록 result[100]={0,1,2,3, ... ,99}를 선언 후 정렬.s
그 후 1,2,3번에 맞게 comparotr를 람다로 넘겨 sort함수를 수행

## 복기
tuple<int,int,int,int> 자료형을 사용하면 sort함수에 lambda 직접 작성하여 넘기지 않더라도 쉽게 정렬할 수 있었다. 
아무것도 넘기지 않으면 오름차순으로 정렬하므로, 1번 값음 음수로, 2번 값은 양수, 3번값도 양수로 하고, 네 번째 tuple 원소에 팀 id를 넣어서 정렬하면 된다.