### PR TITLE
2607 비슷한 단어 & 3758 KCPC

### DIFF
--- a/박민수/2607_비슷한단어.java
+++ b/박민수/2607_비슷한단어.java
@@ -1,0 +1,61 @@
+package SoraeCodingMasters.BOJ2607;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+/***
+ * 백준 2607번
+ * 비슷한 단어
+ * 2024-02-14
+ * 시간 제한 : 1초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int N; // 2 <= N <= 100
+    static int[] alphabet = new int[26];
+    static String origin;
+    static int miss;
+
+    static int answer = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        // init
+        origin = br.readLine();
+
+        for (int i = 1; i < N; i++) {
+            init();
+            String input = br.readLine();
+
+            // 길이가 긴 문자를 기준으로 틀린 개수 세기
+            miss = Math.max(origin.length(), input.length());
+
+            for(char c : input.toCharArray()) {
+                if (alphabet[c - 'A'] > 0) {
+                    miss--;
+                    alphabet[c - 'A']--;
+                }
+            }
+
+            if (miss == 1 || miss == 0) {
+                answer++;
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    public static void init() {
+        Arrays.fill(alphabet, 0);
+
+        for (char c : origin.toCharArray()) {
+            alphabet[c - 'A'] += 1;
+        }
+    }
+
+}

--- a/박민수/3758_KCPC.java
+++ b/박민수/3758_KCPC.java
@@ -1,0 +1,108 @@
+package SoraeCodingMasters.BOJ3758;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 3758번
+ * KCPC
+ * 2024-02-14
+ * 시간 제한 : 1초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int T;
+    static int n, k, t, m; // 3 <= n, k <= 100 / 1 <= t <= n / 3 <= m <= 10,000 /
+    static int i, j, s; // 1 <= i <= n / 1 <= j <= k / 0 <= s <= 100
+    static int[][][] table;
+    static List<Team> teams;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        T = Integer.parseInt(br.readLine());
+
+        while (T-- > 0) {
+            st = new StringTokenizer(br.readLine());
+            n = Integer.parseInt(st.nextToken());
+            k = Integer.parseInt(st.nextToken());
+            t = Integer.parseInt(st.nextToken());
+            m = Integer.parseInt(st.nextToken());
+
+            table = new int[n + 1][k + 1][3]; // 0 : 문제에 대한 최고 점수, 1 : 제출 횟수, 2 : 제출 순서
+
+            for(int a = 1; a <= m; a++) {
+                st = new StringTokenizer(br.readLine());
+                i = Integer.parseInt(st.nextToken());
+                j = Integer.parseInt(st.nextToken());
+                s = Integer.parseInt(st.nextToken());
+
+                table[i][j][0] = Math.max(table[i][j][0] , s);
+                table[i][j][1]++;
+                table[i][j][2] = a;
+            }
+
+            teams = new ArrayList<>();
+            for (int a = 1; a <= n; a++) {
+                int totalScore = 0;
+                int totalSubmit = 0;
+                int lastSubmit = Integer.MIN_VALUE;
+                for(int b = 1; b <= k; b++) {
+                    totalScore += table[a][b][0];
+                    totalSubmit += table[a][b][1];
+                    lastSubmit = Math.max(lastSubmit, table[a][b][2]);
+                }
+                teams.add(new Team(a, totalScore, totalSubmit, lastSubmit));
+            }
+            Collections.sort(teams);
+
+            for (int grade = 0; grade < teams.size(); grade++) {
+                if (teams.get(grade).teamId == t) {
+                    sb.append(grade + 1).append("\n");
+                    break;
+                }
+            }
+        }
+
+        System.out.println(sb);
+    }
+
+    public static class Team implements Comparable<Team> {
+        int teamId;
+        int totalScore;
+        int totalSubmit;
+        int lastSubmit;
+
+        public Team(int teamId, int totalScore, int totalSubmit, int lastSubmit) {
+            this.teamId = teamId;
+            this.totalScore = totalScore;
+            this.totalSubmit = totalSubmit;
+            this.lastSubmit = lastSubmit;
+        }
+
+        @Override
+        public int compareTo(Team o) {
+            if (this.totalScore < o.totalScore) {
+                return 1;
+            } else if (this.totalScore == o.totalScore) {
+                if (this.totalSubmit > o.totalSubmit) {
+                    return 1;
+                } else if (this.totalSubmit == o.totalSubmit) {
+                    return this.lastSubmit - o.lastSubmit;
+                } else {
+                    return  -1;
+                }
+            } else {
+                return -1;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
# BOJ 2607 비슷한단어 

## 사고 흐름

단어를 비교할 때 모든 문자가 틀렸다고 가정하고 구성이 일치한다면 하나씩 상쇄하는 방향으로 문제를 풀었다.

틀린 문자가 1개 or 0개 일 때 문제의 조건을 모두 만족하므로 정답 처리를 해준다.

문자의 길이에 따라 비교 대상이 달라져야 한다는 문제점이 있었지만, 문자의 길이가 큰 값을 기준으로 하면 해결될 수 있는 문제였다.

## 복기
다른 사람들의 풀이를 보니 절댓값을 사용해서 문자 개수의 차이를 계산하였는데 익혀두면 좋을 것 같다.

# BOJ 3758 KCPC

## 사고 흐름

이 문제의 조건을 보고 정렬 문제임을 파악하였다.

정렬의 우선순위는 다음과 같다.

1. 총 점수를 기준으로 내림차순 정렬한다.
2. 총 점수가 같다면 총 제출 수 기준으로 오름차순 정렬한다.
3. 총 제출 수가 같다면 제출 순서를 기준으로 오름차순 정렬한다.

따라서, 정렬을 위해 필요한 정보를 구하기 위해 총 점수, 총 제출 수, 마지막 제출 순서를 얻어야겠다고 생각했다.

이를 구하기 위해서 다음과 같이 3원 테이블을 선언하였다.

![image](https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/75938496/6445b05e-a3ee-4919-a50b-f9fdd9bee0b7)

## 복기
정렬할 때는 Comparator를 구현하거나 Comparable을 구현할 수 있도록 하자.