### PR TITLE
20310 타노스 & 19637 IF문 좀 대신 써줘

### DIFF
--- a/박민수/19637_IF문좀대신써줘.java
+++ b/박민수/19637_IF문좀대신써줘.java
@@ -1,0 +1,95 @@
+package SoraeCodingMasters.BOJ19637;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 19637번
+ * IF문 좀 대신 써줘
+ * 2024-02-15
+ * 시간 제한 : 1초
+ * 메모리 제한 : 1024MB
+ */
+
+public class Main {
+    static int N, M; // 1 <= N, M <= 100,000
+    static String title;
+    static int power;
+    static Map<Integer, String> titles;
+    static int[] powers;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        titles = new HashMap<>();
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            title = st.nextToken();
+            power = Integer.parseInt(st.nextToken());
+
+            titles.putIfAbsent(power, title);
+        }
+
+        powers = titles.keySet().stream().mapToInt(Integer::intValue).toArray();
+        Arrays.sort(powers);
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < M; i++) {
+            int value = Integer.parseInt(br.readLine());
+            int key = lowerBound(value);
+            sb.append(titles.get(powers[key])).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+    public static int binarySearch(int value) {
+        int left = 0;
+        int right = powers.length;
+
+        int answer = 0;
+
+        while(left < right) {
+           int mid = (left + right) / 2;
+
+           if(powers[mid] < value) {
+               // 왼쪽 잘라내기
+               left = mid + 1;
+           } else if (powers[mid] > value){
+               // 오른쪽 잘라내기
+               right = mid;
+           } else {
+               return mid;
+           }
+
+        }
+        return answer;
+    }
+
+    public static int lowerBound(int value) {
+        int left = 0;
+        int right = powers.length;
+
+        while(left < right) {
+            int mid = (left + right) / 2;
+
+            if(powers[mid] < value) {
+                // 왼쪽 잘라내기
+                left = mid + 1;
+            } else {
+                // 오른쪽 잘라내기
+                right = mid;
+            }
+        }
+        return right;
+    }
+}

--- a/박민수/20310_타노스.java
+++ b/박민수/20310_타노스.java
@@ -1,0 +1,55 @@
+package SoraeCodingMasters.BOJ20310;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/***
+ * 백준 20310번
+ * 타노스
+ * 2024-02-15
+ * 시간 제한 : 1초
+ * 메모리 제한 : 1024MB
+ */
+
+public class Main {
+    static char[] S;
+    static int[] count;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        count = new int[2];
+        S = br.readLine().toCharArray();
+
+        // 제거하기 위한 숫자 카운팅
+        for (char c : S) {
+            count[c - '0']++;
+        }
+
+        // 뒤에서 부터 0 제거
+        int zeroCount = count[0] / 2;
+        for (int i = S.length - 1; i >= 0; i--) {
+            if (S[i] == '0' && zeroCount > 0) {
+                zeroCount--;
+                S[i] = 'X';
+            }
+        }
+        // 엪에서 부터 1 제거
+        int oneCount = count[1] / 2;
+        for (int i = 0; i < S.length; i++) {
+            if (S[i] == '1' && oneCount > 0) {
+                oneCount--;
+                S[i] = 'X';
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < S.length; i++) {
+            if (S[i] != 'X') {
+                sb.append(S[i]);
+            }
+        }
+        System.out.println(sb);
+    }
+
+}


### PR DESCRIPTION
# BOJ 20310 타노스

## 사고 흐름

사전 순으로 가장 빠르게 출력해야 하므로 맨 앞 부분에 최대한 0을 많이 배치해야겠다고 생각했다.

우선 제거할 0과 1의 개수를 카운팅하고 입력받은 문자열 뒤에서부터 0을 제거하고 앞에서 부터 1을 제거하여 문제를 해결하였다.

## 복기

딱히 없다.

# BOJ 19637 IF문 좀 대신 써줘

## 사고 흐름

가장 먼저 입력의 크기와 시간 제한을 확인하였다.

### 입력

- 칭호의 수 N (1 <= N <= 100,000)
- 캐릭터의 수 M(1 <= M <= 100,000)

캐릭터 마다 칭호를 부여할 때 완탐으로 돌게되면 시간초과가 발생할 것이라고 생각하였다.

따라서, O(logN)으로 탐색해야하기 때문에 이분 탐색으로 접근하였다.

### 시간 복잡도

최종 시간 복잡도는 O(MlogN)이 된다.

## 복기

이번 문제는 Lower bound 라는 개념을 알고 있었다면 빨리 풀 수 있었을 것 같다.

같은 전투력일 때 처음으로 입력받은 칭호가 출력되어야 한다는 조건 때문에 Map 자료구조를 사용하였는데 Lower bound를 사용하면 그럴 필요가 없기 때문이다.

### Lower bound

Lower bound는 같은 값이 여러 개 있더라도 이분 탐색을 약간 변형하여, **찾고자 하는 값의 이상의 값이 처음 나타나는 위치**를 찾을 수 있다.

예를 들어, Lower bound를 사용하면 `1 2 3 5 7 9 11 15` 이라는 배열이 있을 때, 6 이상의 값이 처음 나오는 위치인 7의 인덱스를 구할 수 있다.

### Upper bound

Upper bound는 찾고자 하는 값 보다 큰 값이 처음으로 나타나는 위치를 찾을 때 사용한다.


### 비내림차순
<img width="756" alt="image" src="https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/75938496/a41e9812-d291-4977-871e-f57ee40a5ff1">
