### PR TITLE
22233 가희와 키워드 & 1927 최소 

### DIFF
--- a/박민수/11501_주식.java
+++ b/박민수/11501_주식.java
@@ -1,0 +1,73 @@
+package SoraeCodingMasters.BOJ11501;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 11501번
+ * 주식
+ * 2024-02-17
+ * 시간 제한 : 5초
+ * 메모리 제한 : 256MB
+ */
+
+public class Main {
+    static int T;
+    static int N; // 2 <= N <= 1,000,000
+    static int[] chart;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        T = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+
+        // O(T)
+        while (T-- > 0) {
+            // init
+            N = Integer.parseInt(br.readLine());
+            chart = new int[N];
+            st = new StringTokenizer(br.readLine());
+            // O(N)
+            for(int i = 0; i < N; i++) {
+                chart[i] = Integer.parseInt(st.nextToken());
+            }
+
+            // O(N^2)
+            sb.append(calculateBenefit(0, N)).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    public static long calculateBenefit(int s, int e) {
+
+        // 종료 조건 : 모든 배열을 탐색한 경우
+        if (s >= e) {
+            return 0;
+        }
+        // O(N)
+        int index = findIndex(s, e);
+
+        long benefit = 0;
+        for (int i = s; i < index; i++) {
+            benefit += (chart[index] - chart[i]);
+        }
+        // O(N)
+        return benefit + calculateBenefit(index + 1, e);
+    }
+
+    public static int findIndex(int s, int e) {
+        int maxValue = Integer.MIN_VALUE;
+        int maxIndex = -1;
+        for(int i = s; i < e; i++) {
+            if (maxValue < chart[i]) {
+                maxValue = chart[i];
+                maxIndex = i;
+            }
+        }
+
+        return maxIndex;
+    }
+}

--- a/박민수/1927_최소힙.java
+++ b/박민수/1927_최소힙.java
@@ -1,0 +1,43 @@
+package SoraeCodingMasters.BOJ1927;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+/***
+ * 백준 1927번
+ * 최소 힙
+ * 2024-02-16
+ * 시간 제한 : 1초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int N; // 1 <= N <= 100,000
+    static Queue<Integer> pq;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        pq = new PriorityQueue<>((a, b) -> b - a);
+
+        StringBuilder sb = new StringBuilder();
+        while (N-- > 0) {
+            int input = Integer.parseInt(br.readLine());
+
+            if (input == 0 && pq.isEmpty()) {
+                sb.append(0).append("\n");
+            } else if (input == 0) {
+                sb.append(pq.poll()).append("\n");
+            } else {
+                pq.add(input);
+            }
+        }
+
+        System.out.println(sb);
+    }
+
+}

--- a/박민수/20006_랭킹전대기열.java
+++ b/박민수/20006_랭킹전대기열.java
@@ -1,0 +1,90 @@
+package SoraeCodingMasters.BOJ20006;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 20006번
+ * 랭킹전 대기열
+ * 2024-02-17
+ * 시간 제한 : 1초
+ * 메모리 제한 : 256MB
+ */
+
+public class Main {
+    static int p, m; // 1 <= p, m <= 300
+    static int l; // 1 <= l <= 500
+    static String n;
+
+    static List<List<Player>> rooms;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        p = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        rooms = new ArrayList<>();
+
+        for (int i = 0; i < p; i++) {
+            st = new StringTokenizer(br.readLine());
+            l = Integer.parseInt(st.nextToken());
+            n = st.nextToken();
+
+            requestJoin(new Player(l, n));
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (List<Player> room : rooms) {
+            if (room.size() == m) {
+                sb.append("Started!").append("\n");
+            } else {
+                sb.append("Waiting!").append("\n");
+            }
+
+            Collections.sort(room);
+
+            for (Player player : room) {
+                sb.append(player.score).append(" ").append(player.nickname).append("\n");
+            }
+        }
+
+        System.out.println(sb);
+    }
+
+    public static void requestJoin(Player player) {
+        for (List<Player> room : rooms) {
+            int roomScore = room.get(0).score;
+            int playerScore = player.score;
+            // 절대값이 10 이내 & 풀방이 아니라면
+            if (Math.abs(roomScore - playerScore) <= 10 && room.size() < m) {
+                room.add(player);
+                return;
+            }
+        }
+        // 방이 없다면
+        rooms.add(new ArrayList<>());
+        rooms.get(rooms.size() - 1).add(player);
+    }
+
+    public static class Player implements Comparable<Player>{
+        int score;
+        String nickname;
+
+        public Player(int score, String nickname) {
+            this.score = score;
+            this.nickname = nickname;
+        }
+
+        @Override
+        public int compareTo(Player o) {
+            return this.nickname.compareTo(o.nickname);
+        }
+    }
+
+}

--- a/박민수/22233_가희와키워드.java
+++ b/박민수/22233_가희와키워드.java
@@ -1,0 +1,49 @@
+package SoraeCodingMasters.BOJ22233;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 22233번
+ * 가희와 키워드
+ * 2024-02-16
+ * 시간 제한 : 1.5초
+ * 메모리 제한 : 512MB
+ */
+
+public class Main {
+    static int N, M; // 1 <= N, M <= 200,000
+    static HashMap<String, Boolean> words;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        words = new HashMap<>();
+
+        for (int i = 0; i < N; i++) {
+            words.put(br.readLine(), true);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine(), ",");
+            while(st.hasMoreTokens()) {
+                String word = st.nextToken();
+                if(words.getOrDefault(word, false)) {
+                    words.put(word, false);
+                    N--;
+                }
+            }
+            sb.append(N).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+
+}


### PR DESCRIPTION
# BOJ 22233 가희와 키워드

## 사고 흐름

가장 먼저 입력의 크기와 시간 제한을 확인하였다.

### 입력

- 메모장의 키워드 N
- 블로그에 쓴 글 M(1 <= N, M <= 200,000)

메모장에서 키워드를 찾기위해 O(N)의 시간 복잡도를 사용하는 것은 시간 초과가 날 것이라고 생각하였다.

키워드가 메모장에 있는지와 사용되었는지만 확인하면 되기 때문에 `Map<String, Boolean>` 을 선언하여 메모장에 있는 키워드를 관리하였다.

## 복기

딱히 없다.

# BOJ 1927 최소 힙

## 사고 흐름

최소 힙과 관련된 문제이므로 PriorityQueue를 이용하여 풀어야겠다고 생각했다.

### 시간 복잡도

- 삽입/삭제 : O(logN)

## 복기

### 우선순위 설정

우선순위 큐의 우선순위는 Comparator lambda expression으로 정해주면 될 것 같다.

```java
// 최소 힙 : default
Queue<Integer> pq = new PriorityQueue<>();

// 최대 힙
Queue<Integer> pq = new PriorityQueue<>((a, b) -> b - a);
```
