### PR TITLE
20006 랭킹전 대기열 & 11501 주식

### DIFF
--- a/김남주/11501_주식.cpp
+++ b/김남주/11501_주식.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <algorithm>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+typedef long long ll;
+int a[1'000'000]{ 0, };
+
+int main() {
+	fastio;
+	//read_input;
+	int T;
+	cin >> T;
+
+	int n;
+	while (T--) {
+		cin >> n;
+		ll ans = 0;
+		int highest = 0;
+		for (int i = 0;i < n;i++) cin >> a[i];
+		for (int i = n - 1;i >= 0;i--) {
+			highest = max(highest, a[i]);
+			ans += (highest - a[i]);
+		}
+		cout << ans << '\n';
+	}
+}

--- a/김남주/1406_에디터.cpp
+++ b/김남주/1406_에디터.cpp
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+struct node {
+	node* prev;
+	node* next;
+	char c;
+};
+
+node node_pool[600'000 + 5];
+int node_num = 0;
+node* get_new_node() {
+	return &node_pool[node_num++];
+}
+
+node* insert(char c, node* target) {
+	auto new_node = get_new_node();
+	new_node->c = c;
+	new_node->next = target->next, new_node->prev = target;
+	target->next->prev = new_node;
+	target->next = new_node;
+	return new_node;
+}
+
+void del(node* target) {
+	target->prev->next = target->next;
+	target->next->prev = target->prev;
+}
+
+string str;
+int main() {
+	fastio;
+	//read_input;
+	cin >> str;
+	node* head = get_new_node();
+	node* tail = get_new_node();
+	head->next = tail, head->prev = tail;
+	tail->next = head, tail->prev = head;
+
+	node* cur = head;
+	for (auto& c : str) {
+		cur=insert(c, cur);
+	}
+	int m;
+	char cmd, c;
+	cin >> m;
+	cur = tail;
+	for (int i = 0;i < m;i++) {
+		cin >> cmd;
+		switch (cmd)
+		{
+		case'L':
+			if (cur->prev == head) break;
+			cur = cur->prev;
+			break;
+		case'D':
+			if (cur == tail) break;
+			cur = cur->next;
+			break;
+		case'B':
+			if (cur->prev == head) break;
+			del(cur->prev);
+			break;
+		case'P':
+			cin >> c;
+			insert(c, cur->prev);
+			break;
+		}
+	}
+	cur = head->next;
+	while (cur != tail) {
+		cout << cur->c;
+		cur = cur->next;
+	}
+}

--- a/김남주/1406_에디터.cpp
+++ b/김남주/1406_에디터.cpp
@@ -1,80 +1,46 @@
 #include <iostream>
 #include <algorithm>
-#include <vector>
+#include <cstring>
 
 #define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
 #define read_input freopen("input.txt","r",stdin)
 using namespace std;
 
-struct node {
-	node* prev;
-	node* next;
-	char c;
-};
+#define LMAX 600'000
+#define RMAX 500'000
 
-node node_pool[600'000 + 5];
-int node_num = 0;
-node* get_new_node() {
-	return &node_pool[node_num++];
-}
+char lstack[LMAX], rstack[RMAX];
+int lidx, ridx;
 
-node* insert(char c, node* target) {
-	auto new_node = get_new_node();
-	new_node->c = c;
-	new_node->next = target->next, new_node->prev = target;
-	target->next->prev = new_node;
-	target->next = new_node;
-	return new_node;
-}
-
-void del(node* target) {
-	target->prev->next = target->next;
-	target->next->prev = target->prev;
-}
-
-string str;
 int main() {
 	fastio;
 	//read_input;
-	cin >> str;
-	node* head = get_new_node();
-	node* tail = get_new_node();
-	head->next = tail, head->prev = tail;
-	tail->next = head, tail->prev = head;
-
-	node* cur = head;
-	for (auto& c : str) {
-		cur=insert(c, cur);
-	}
+	cin >> lstack;
 	int m;
-	char cmd, c;
 	cin >> m;
-	cur = tail;
-	for (int i = 0;i < m;i++) {
+	lidx = strlen(lstack) - 1;
+	ridx = -1;
+
+	char cmd, x;
+	while (m--) {
 		cin >> cmd;
-		switch (cmd)
-		{
-		case'L':
-			if (cur->prev == head) break;
-			cur = cur->prev;
-			break;
-		case'D':
-			if (cur == tail) break;
-			cur = cur->next;
-			break;
-		case'B':
-			if (cur->prev == head) break;
-			del(cur->prev);
-			break;
-		case'P':
-			cin >> c;
-			insert(c, cur->prev);
-			break;
+		if (cmd == 'L') {
+			if (lidx < 0) continue;
+			rstack[++ridx] = lstack[lidx--];
+		}
+		else if (cmd == 'D') {
+			if (ridx < 0) continue;
+			lstack[++lidx] = rstack[ridx--];
+		}
+		else if (cmd == 'B') {
+			if (lidx < 0) continue;
+			lidx--;
+		}
+		else {
+			cin >> x;
+			lstack[++lidx] = x;
 		}
 	}
-	cur = head->next;
-	while (cur != tail) {
-		cout << cur->c;
-		cur = cur->next;
-	}
+	for (int i = 0;i <= lidx;i++) cout << lstack[i];
+	for (int i = ridx;i >=0;i--) cout << rstack[i];
 }

--- a/김남주/20006_랭킹전대기열.cpp
+++ b/김남주/20006_랭킹전대기열.cpp
@@ -1,0 +1,65 @@
+#include <iostream>
+#include <algorithm>
+#include <list>
+#include <set>
+#include <string>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+#define MAX 300
+
+int P, M;
+
+struct player {
+	int level;
+	string name;
+	bool operator< (const player& other) const  {
+		return name < other.name;
+	}
+};
+
+int r_n = 0;
+int rlev[MAX];
+set<player> players[MAX];
+
+bool can_enter(int& lev, int& id) {
+	return !(lev<rlev[id] - 10 || lev>rlev[id] + 10);
+}
+
+
+int main() {
+	fastio;
+	//read_input;
+	cin >> P >> M;
+
+	int l;
+	string name;
+	list<int> cur_rooms;
+	for (int i = 0;i < P;i++) {
+		cin >> l >> name;
+		bool entered = false;
+		for (auto it = cur_rooms.begin();it != cur_rooms.end();it++) {
+			if (can_enter(l, *it)) {
+				entered = true;
+				players[*it].insert({ l,name });
+				if (players[*it].size() >= M) {
+					cur_rooms.erase(it);
+				}
+				break;
+			}
+		}
+		if (entered) continue;
+		rlev[r_n] = l;
+		players[r_n].insert({ l,name });
+		if (M!=1) {
+			cur_rooms.push_back(r_n);
+		}
+		r_n++;
+	}
+	for (int i = 0;i < r_n;i++) {
+		if (players[i].size() >= M) cout << "Started!" << '\n';
+		else cout << "Waiting!" << '\n';
+		for (auto& p : players[i]) cout << p.level << ' ' << p.name << '\n';
+	}
+} 


### PR DESCRIPTION
# 랭킹전 대기열
## 사고 흐름
문제를 읽으면서 ' 입장 가능한 방이 여러 개라면 먼저 생성된 방에 입장', '방은 생성된 순서대로 출력', '방에 있는 플레이어들의 이름은 사전순으로 출력' -> 정렬이나 set (Java에서는 TreeSet) 등을 이용해야 하나? 하면서 읽음

플레이어수는 최대 300, 방의 정원은 최소 1이므로 최대 300개의 방이 만들어질 수 있음을 확인 => 크기 300의 배열들을 통해 입력들을 저장할 수 있음을 생각 

어떤 자료구조를 선언해야 하는가?
1. '매칭가능한 방이 있나 없나' 확인이 필요 + 방이 생성된 순으로 확인하면 좋음
  * 방이 생성될 때마다 컨테이너의 뒤에 넣어 주면 알아서 생성된 순으로 정렬
  * 그러나 나중에 생성된 방이 먼저 게임이 시작될 수 있으므로 컨테이너 중간의 원소를 삭제하는 경우가 발생할 수 있음
  * 이를 O(1)으로 처리하고 싶으므로 **연결 리스트** 사용
 2. 매칭 가능한 방의 레벨 조건 확인 필요
   * 방이 생성될 때마다 방 마다 처음 플레이어의 레벨을 저장
 3. 방의 플레이어의 이름을 사전순으로 출력해야 함
  * 방 마다 string의 set(TreeSet)을 선언해서 방에 들어갈때 마다 push 해줌
 4. 현재 방에 몇명이 있는지?
  * 3번 자료구조의 size() 멤버함수로 체크
 
2,3번은 크기 300의 배열을 통해 선언

1번은 매칭가능한 방의 모든 정보를 연결리스트에 넣으면 메모리 낭비가 되므로 2,3번 배열의 인덱스를 마치 방의 id처럼 활용하여 해당 id를 넣어줌

## 복기
사실 최대 방이 300이므로 위처럼 연결리스트를 만들지 않더라도 시간초과가 발생하지 않을 문제이다. 만약 실전에서 이와 같이 주어졌다면 복잡하게 자료구조를 생각하다가 문제 풀이 시간이 늦어질 수 있음
그럴때는 그냥 연결리스트 없이 300개의 방을 모두 선형 탐색하는 코드를 작성하는 것이 더 나을 수 있다.

또한 3번에서 set(TreeSet)을 선언하지 않고 나중에 출력할 때 정렬해줘도 문제 없음
set을 사용하면 메모리를 더 잡아먹음.
정렬할 때도 굳이 lambda를 넘기지 않고 pair<string,int> type으로 선언해서 sort함수를 사용하면 알아서 사전순으로 정렬되게끔 하면 된다.


---


# 주식
## 사고 흐름
이런 최적화(최대, 최소 찾기) 문제는 보통 그리디나 DP로 풀수 있음
그림을 그려보면서 규칙을 찾았고 이를 재정의 하면 -> 미래 최고 고점에 판다.
이를 O(N)으로 풀기 위해서는 입력을 모두 받은 후 뒤에서 부터 반대로 순회하면서 고점을 갱신해주고 (고점 - 현재 값)을 정답에 더해주면 된다.
## 복기
없음