### PR TITLE
1406 에디터 & 2304 창고 다각형

### DIFF
--- a/박민수/1406_에디터.java
+++ b/박민수/1406_에디터.java
@@ -3,8 +3,10 @@ package SoraeCodingMasters.BOJ1406;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Queue;
 import java.util.StringTokenizer;
 
@@ -17,32 +19,37 @@ import java.util.StringTokenizer;
  */
 
 public class Main {
-    static final int MAX_LEN = 600_000;
     static String input;  // 1 <= len(input) <= 100,000
     static int M; // 1 <= M <= 500,000
     static List<Character> editor = new LinkedList<>();
     static char command;
-    static int cursor;
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringTokenizer st;
 
         input = br.readLine();
-        cursor = input.length();
         for (char c : input.toCharArray()) {
             editor.add(c);
         }
 
         M = Integer.parseInt(br.readLine());
 
-        while(M-- > 0) {
-            String s = br.readLine();
-            command = s.charAt(0);
+        ListIterator<Character> iterator = editor.listIterator(); // Linked List의 cursor
+        for (char c : editor) {
+            iterator.next(); // 맨 끝으로 옮기기
+        }
 
-            if (command == 'L' && cursor > 0) cursor--;
-            else if (command == 'D' && cursor < editor.size()) cursor++;
-            else if (command == 'B' && cursor > 0) editor.remove(--cursor);
-            else if (command == 'P') editor.add(cursor++, s.charAt(2));
+        while(M-- > 0) {
+            st = new StringTokenizer(br.readLine());
+            command = st.nextToken().charAt(0);
+
+            if (command == 'L' && iterator.hasPrevious()) iterator.previous();
+            else if (command == 'D' && iterator.hasNext()) iterator.next();
+            else if (command == 'B' && iterator.hasPrevious()) {
+                iterator.previous();
+                iterator.remove();
+            }
+            else if (command == 'P') iterator.add(st.nextToken().charAt(0));
         }
 
         StringBuilder sb = new StringBuilder();

--- a/박민수/1406_에디터.java
+++ b/박민수/1406_에디터.java
@@ -1,0 +1,57 @@
+package SoraeCodingMasters.BOJ1406;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 1406번
+ * 에디터
+ * 2024-02-18
+ * 시간 제한 : 2초
+ * 메모리 제한 : 512MB
+ */
+
+public class Main {
+    static final int MAX_LEN = 600_000;
+    static String input;  // 1 <= len(input) <= 100,000
+    static int M; // 1 <= M <= 500,000
+    static List<Character> editor = new LinkedList<>();
+    static char command;
+    static int cursor;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        input = br.readLine();
+        cursor = input.length();
+        for (char c : input.toCharArray()) {
+            editor.add(c);
+        }
+
+        M = Integer.parseInt(br.readLine());
+
+        while(M-- > 0) {
+            String s = br.readLine();
+            command = s.charAt(0);
+
+            if (command == 'L' && cursor > 0) cursor--;
+            else if (command == 'D' && cursor < editor.size()) cursor++;
+            else if (command == 'B' && cursor > 0) editor.remove(--cursor);
+            else if (command == 'P') editor.add(cursor++, s.charAt(2));
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        for (char c : editor) {
+            sb.append(c);
+        }
+
+        System.out.println(sb);
+    }
+
+}

--- a/박민수/2304_창고다각형.java
+++ b/박민수/2304_창고다각형.java
@@ -1,0 +1,111 @@
+package SoraeCodingMasters.BOJ2304;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 2304번
+ * 창고 다각형
+ * 2024-02-18
+ * 시간 제한 : 2초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int N; // 1 <= N <= 1,000
+    static Stick[] sticks;
+    static int height, location;
+    static int total = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        sticks = new Stick[N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            location = Integer.parseInt(st.nextToken());
+            height = Integer.parseInt(st.nextToken());
+            sticks[i] = new Stick(location, height);
+        }
+
+        Arrays.sort(sticks);
+        int lowerBound = findLowerBound();
+        int upperBound = findUpperBound();
+
+        // 고점 전
+        Stick beforeMax = sticks[0];
+        for (int i = 1; i <= lowerBound; i++) {
+            if (beforeMax.height < sticks[i].height) {
+                total += beforeMax.height * (sticks[i].location - beforeMax.location);
+                beforeMax = sticks[i];
+            }
+        }
+
+        // 고점
+        total += (sticks[upperBound].location - sticks[lowerBound].location + 1) * sticks[lowerBound].height;
+
+        // 고점 후
+        Stick afterMax = sticks[N - 1];
+        for (int i = N - 1; i >= upperBound; i--) {
+            if (afterMax.height < sticks[i].height) {
+                total += afterMax.height * (afterMax.location - sticks[i].location);
+                afterMax = sticks[i];
+            }
+        }
+
+        System.out.println(total);
+    }
+
+    public static int findLowerBound() {
+        int maxValue = Integer.MIN_VALUE;
+        int maxIndex = -1;
+
+        for (int i = 0; i < N; i++) {
+            if (maxValue < sticks[i].height) {
+                maxValue = sticks[i].height;
+                maxIndex = i;
+            }
+        }
+
+        return maxIndex;
+    }
+
+    public static int findUpperBound() {
+        int maxValue = Integer.MIN_VALUE;
+        int maxIndex = -1;
+
+        for (int i = 0; i < N; i++) {
+            if (maxValue <= sticks[i].height) {
+                maxValue = sticks[i].height;
+                maxIndex = i;
+            }
+        }
+
+        return maxIndex;
+    }
+
+
+    public static class Stick implements Comparable<Stick> {
+        int location;
+        int height;
+
+        @Override
+        public int compareTo(Stick o) {
+            return this.location - o.location;
+        }
+
+        public Stick(int location, int height) {
+            this.location = location;
+            this.height = height;
+        }
+    }
+}
+


### PR DESCRIPTION
# BOJ 1406 에디터

## 사고 흐름

우선 삽입과 삭제가 빈번하게 발생하는 문제이므로 연결 리스트를 사용해서 풀어야겠다고 접근하였다.

그러나, 삽입/삭제 시 인덱스에 바로 접근하는 것이 아니라 `Head`와 `Tail`을 제외하고 하나하나 살펴보며 처리하기 때문에 O(N)의 시간 복잡도를 갖게 되어서 시간 초과가 발생하였다.

따라서, `ListIterator`를 사용해야 이 문제의 커서처럼 양방향으로 움직이며 O(1)의 시간 복잡도로 삽입/삭제 연산을 진행할 수가 있다.

## 복기

### ListIterator

![image](https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/75938496/42790153-1753-4396-b632-0a44065cfc3c)

# BOJ 2304 창고 다각형

## 사고 흐름
![image](https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/75938496/c91f7537-5109-4c31-bb68-d823c1834753)

위의 그림과 같이 고점 전, 고점, 고점 후 세 등분으로 나눠서 창고 면적을 구해야겠다고 생각하였다.

1. 세 구간을 구분하기 위해서 고점의 lower_bound와 upper_bound를 구하였다.
2. 고점 전은 첫 번째 막대 부터 고점의 lower_bound 번째 막대까지 면적을 구한다.
3. 고점은 고점의 lower_bound 번째 막대와 고점의 upper_bound 번째 막대까지 면적을 구한다.
4. 고점 후는 마지막 막대에서 고점의 upper_bound 번째 막대까지 면적을 구한다.

## 복기

monotone_stack 으로도 풀 수 있다고 하는데 공부해보고 도전해봐야겠다.

