### PR TITLE
2075 N 번째 큰  & 1138 한 줄로 서기

### DIFF
--- a/박민수/1138_한줄로서기.java
+++ b/박민수/1138_한줄로서기.java
@@ -1,0 +1,51 @@
+package SoraeCodingMasters.BOJ1138;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 1138번
+ * 한 줄로 서기
+ * 2024-02-19
+ * 시간 제한 : 2초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int N; // 1 <= N <= 10
+    static int[] line;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        line = new int[N];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            int count = 0;
+            int left = Integer.parseInt(st.nextToken());
+            for (int j = 0; j < N; j++) {
+                if (count == left && line[j] == 0) {
+                    line[j] = i;
+                    break;
+                }
+                if (line[j] == 0) count++;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int people : line) {
+            sb.append(people).append(" ");
+        }
+        System.out.println(sb);
+    }
+
+    public static void print() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < N; i++) {
+            sb.append(line[i]).append(" ");
+        }
+        System.out.println(sb);
+    }
+}

--- a/박민수/2075_N번째큰수.java
+++ b/박민수/2075_N번째큰수.java
@@ -1,0 +1,42 @@
+package SoraeCodingMasters.BOJ2075;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 2075번
+ * N번째 큰 수
+ * 2024-02-19
+ * 시간 제한 : 1초
+ * 메모리 제한 : 12MB
+ */
+
+public class Main {
+    static int N; // 1 <= N <= 1,500
+    static Queue<Integer> pq = new PriorityQueue<>((a, b) -> b - a); // 최대 힙
+    static int answer = 0;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                pq.add(Integer.parseInt(st.nextToken()));
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            answer = pq.poll();
+        }
+
+        System.out.println(answer);
+    }
+
+}


### PR DESCRIPTION
# BOJ 2075 N 번째 큰 수

## 사고 흐름
메모리 제한이 12MB이기 때문에 N^2 (1 <= N <= 1,500) 크기의 int형 배열은 선언할 수 있다고 생각했다.

최대 힙의 우선순위 큐를 선언하고 N^2개의 수를 우선순위 큐에 다 넣은 후 N 번째 수를 출력하여 해결하였다.

## 복기

이 문제를 슬라이딩 윈도우 알고리즘을 사용하면 좀 더 <u>**메모리 최적화**</u>를 할 수 있다.

결국 구해야하는 것은 **N^2의 숫자를 오름차순으로 정렬했을 때, 마지막 N개의 숫자 중 최솟값**이다.

다음의 과정으로 이를 구할 수 있다.
1. 최소 힙의 우선순위 큐를 선언하고 
2. 우선순위 큐에 N개의 숫자를 유지하면서 
3. 현재 우선순위 큐의 최솟값보다 입력값이 더 크다면 맞교환으로 갱신

# BOJ 1138 한 줄로 서기

## 사고 흐름
입력의 크기가 작아서 시간 복잡도를 크게 고려하지 않고 풀었다.

비어있는 자리 중 가장 키가 작은 사람부터 순서대로 자리를 배치해주어서 해결하였다.

### 시간 복잡도
최종 시간 복잡도는 O(N^2) 이다.

## 복기
 
딱히 없다.