### PR TITLE
1406 에디터 & 2304 창고 다각형

### DIFF
--- a/김남주/2304_창고다각형.cpp
+++ b/김남주/2304_창고다각형.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <algorithm>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+typedef pair<int, int> pii;
+#define MAX 1000
+int n;
+pii info[MAX + 1];
+int nh[MAX];
+int main() {
+	fastio;
+	//read_input;
+	cin >> n;
+	for (int i = 0;i < n;i++) {
+		cin >> info[i].first >> info[i].second;
+	}
+	sort(info, info + n);
+	info[n].first = info[n - 1].first + 1;
+	int highest = 0;
+	for (int i = n - 1;i >= 0;i--) {
+		highest = max(highest, info[i+1].second);
+		nh[i] = highest;
+	}
+	int ans = 0, ch = 0;
+	for (int i = 0;i < n;i++) {
+		if (ch < info[i].second) {
+			ch = info[i].second;
+		}
+		ans += ch;
+		if (ch > nh[i]) {
+			ch = nh[i];
+		}
+		ans += ch * (info[i + 1].first - (info[i].first + 1));
+	}
+	cout << ans;
+}


### PR DESCRIPTION
# 에디터
## 사고 흐름
커서 왼쪽에 있는 문자를 삭제하거나 삽입한다 
-> 컨테이너 중간에 삽입하거나 삭제한다 
-> 이를 O(1)으로 처리하기 위해 연결리스트를 사용해야 한다.

위의 느낌으로 문제를 생각했고 연결리스트를 직접 구현하여 풀음
## 복기
스택으로 푸는 방법을 봤었는데 어떤 부분에서 스택을 사용해야 한다고 느껴야 되는지 잘 몰랐다.
그러나 스택을 사용하게 된다면 양방향 연결리스트의 포인터가 필요 없으므로 메모리를 절약할 수 있고,
삭제나 삽입시에 포인터를 수정할 필요가 없으므로 같은 O(1) 이라도 더 빠르다.

스택으로 푸는 풀이는 두번째 커밋에 반영

---

# 창고 다각형
## 사고흐름
가장 간단한 방법으로 브루트포스를 생각했었는데 브루트포스로 구현한다면 각각의 재귀 호출에서 어떤 처리를 할지 생각했어야 함, 시간안에 들어오려면 창고 다각형의 높이를 일정으로 내리거나 줄인다는 식으로 설계해야 하는데 이는 구현하기 어려우므로 규칙을 찾기로 생각
-> 현재의 위치에서 다음에 만날 기둥의 최대 높이를 기록해서 이를 활용하기로 함
* 현재 창고 다각형의 높이가 기둥보다 낮을 경우 -> 기둥의 높이만큼 올린다.
* 다음에 만날 기둥의 최대 높이가 현재 창고 다각형 높이보다 낮은 경우 -> 다음에 만날 기둥의 최대 높이만큼 낮춘다.
## 복기
문제의 조건에 기둥의 위치가 최대 1000으로 주어지므로 문제의 코드를 조금 더 간단하고 효율적으로 작성하려면,
1000 사이즈의 배열을 선언하고 인덱스를 위치로 활용하여 기둥의 높이를 저장하는 방식을 채택하는게 더 나았을 것 같다.