### PR TITLE
2075 N번째 큰 수 & 1138 한 줄로 서기 & 1260 DFS와 BFS & 14940 쉬운 최단거리

### DIFF
--- a/김남주/1138_한줄로서기.cpp
+++ b/김남주/1138_한줄로서기.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+int n;
+
+int main() {
+	fastio;
+	//read_input;
+	cin >> n;
+	vector<int> ans(n);
+	int cur;
+	for (int i = 1;i <= n;i++) {
+		cin >> cur;
+		int cnt = 0;
+		for (int j = 0;j < n;j++) {
+			if (ans[j]) continue;
+			if (cnt++ == cur) ans[j] = i;
+		}
+	}
+	for (auto& i : ans)cout << i << ' ';
+}

--- a/김남주/1260_DFS와BFS.cpp
+++ b/김남주/1260_DFS와BFS.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <queue>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+#define MAX 1000
+int n, m, v;
+bool vis[MAX+1];
+vector<int> g[MAX+1];
+
+void dfs(int cur) {
+	cout << cur << ' ';
+	vis[cur] = true;
+	for (auto& next : g[cur]) {
+		if (vis[next]) continue;
+		dfs(next);
+	}
+}
+
+void bfs() {
+	queue<int> q;
+	q.push(v);
+	vis[v] = true;
+	while (!q.empty()) {
+		auto cur = q.front();
+		cout << cur << ' ';
+		q.pop();
+		for (auto& next : g[cur]) {
+			if (vis[next]) continue;
+			vis[next] = true;
+			q.push(next);
+		}
+	}
+}
+
+int main() {
+	fastio;
+	//read_input;
+	cin >> n >> m >> v;
+	int a, b;
+	int mn = 0;
+	for (int i = 0;i < m;i++) {
+		cin >> a >> b;
+		g[a].push_back(b);
+		g[b].push_back(a);
+		mn = max({mn,a,b});
+	}
+	for (int i = 1;i <= mn;i++) sort(g[i].begin(), g[i].end());
+	dfs(v);
+	memset(vis, false, sizeof(vis));
+	cout << '\n';
+	bfs();
+}

--- a/김남주/14940_쉬운최단거리.cpp
+++ b/김남주/14940_쉬운최단거리.cpp
@@ -12,7 +12,6 @@ typedef pair<int, int> pii;
 #define MAX 1000
 int n, m;
 int g[MAX][MAX];
-int dist[MAX][MAX];
 int dy[4]{ 0,0,1,-1 }, dx[4]{ 1,-1,0,0 };
 const int INF = 987654321;
 int main() {
@@ -24,24 +23,29 @@ int main() {
 		cin >> g[i][j];
 		if (g[i][j] == 2) sy = i, sx = j;
 	}
-	queue<pii> q;
-	dist[sy][sx] = 1;
-	q.push({sy,sx});
+	for (int i = 0;i < n;i++) for (int j = 0;j < m;j++) {
+		if (g[i][j] == 1)g[i][j] = -1;
+		else g[i][j] = 0;
+	}
+	g[sy][sx] = 1;
+	queue<pair<int, int>> q;
+	q.push({ sy,sx });
 	while (!q.empty()) {
 		auto [cy, cx] = q.front();
 		q.pop();
-
+		
 		for (int d = 0;d < 4;d++) {
 			int ny = cy + dy[d], nx = cx + dx[d];
-			if (ny < 0 || ny >= n || nx < 0 || nx >= m || g[ny][nx]==0 || dist[ny][nx]>0) continue;
-			dist[ny][nx] = dist[cy][cx] + 1;
+			if (ny < 0 || ny >= n || nx < 0 || nx >= m || g[ny][nx] >= 0) continue;
+			g[ny][nx] = g[cy][cx] + 1;
 			q.push({ ny,nx });
 		}
 	}
 	for (int i = 0;i < n;i++) {
 		for (int j = 0;j < m;j++) {
-			if (!dist[i][j]) cout << (g[i][j] == 0 ? 0 : -1) << ' ';
-			else cout << dist[i][j]-1 << ' ';
+			if (g[i][j] >= 1) cout << g[i][j] - 1;
+			else cout << g[i][j];
+			cout << ' ';
 		}
 		cout << '\n';
 	}

--- a/김남주/14940_쉬운최단거리.cpp
+++ b/김남주/14940_쉬운최단거리.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <queue>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+typedef pair<int, int> pii;
+#define MAX 1000
+int n, m;
+int g[MAX][MAX];
+int dist[MAX][MAX];
+int dy[4]{ 0,0,1,-1 }, dx[4]{ 1,-1,0,0 };
+const int INF = 987654321;
+int main() {
+	fastio;
+	//read_input;
+	cin >> n >> m;
+	int sy,sx;
+	for (int i = 0;i < n;i++) for (int j = 0;j < m;j++) {
+		cin >> g[i][j];
+		if (g[i][j] == 2) sy = i, sx = j;
+	}
+	queue<pii> q;
+	dist[sy][sx] = 1;
+	q.push({sy,sx});
+	while (!q.empty()) {
+		auto [cy, cx] = q.front();
+		q.pop();
+
+		for (int d = 0;d < 4;d++) {
+			int ny = cy + dy[d], nx = cx + dx[d];
+			if (ny < 0 || ny >= n || nx < 0 || nx >= m || g[ny][nx]==0 || dist[ny][nx]>0) continue;
+			dist[ny][nx] = dist[cy][cx] + 1;
+			q.push({ ny,nx });
+		}
+	}
+	for (int i = 0;i < n;i++) {
+		for (int j = 0;j < m;j++) {
+			if (!dist[i][j]) cout << (g[i][j] == 0 ? 0 : -1) << ' ';
+			else cout << dist[i][j]-1 << ' ';
+		}
+		cout << '\n';
+	}
+}

--- a/김남주/2075_N번째큰수.cpp
+++ b/김남주/2075_N번째큰수.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <algorithm>
+#include <queue>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+#define MAX 1'500
+
+int n, input[MAX][MAX];
+
+struct comp {
+	bool operator()(int& a, int& b) {
+		return input[a / n][a % n] < input[b / n][b % n];
+	}
+};
+
+int main() {
+	fastio;
+	//read_input;
+	cin >> n;
+	for (int i = 0;i < n;i++) for (int j = 0;j < n;j++) cin >> input[i][j];
+	
+	priority_queue<int, vector<int>,comp> pq;
+	for (int i = 0;i < n;i++)pq.push((n - 1) * n + i);
+	int x = 0;
+	while (true) {
+		auto cur = pq.top();
+		pq.pop();
+		if (++x == n) {
+			cout << input[cur / n][cur % n];
+			return 0;
+		}
+		if ((cur/n))pq.push(cur - n);
+	}
+}


### PR DESCRIPTION
# N번째 큰 수
## 사고 흐름
시간 제한이 1초이고 최대 225만 사이즈의 배열이므로 정렬로만 풀어도 시간안에 들어갈 수 있을 것 같다고 생각했지만, 메모리 제한이 12MB 이므로 입력을 저장하는 것외에 다른 배열을 선언하는 것은 메모리 초과에 들 수 있다고 생각.

결국 정렬이 아닌 빨리 풀 아이디어를 찾았어야 했는데
아래에 있는 수가 위에 있는 수보다 항상 크다는 조건이 있으므로 맨 아래부터 하나씩 검사하면 된다.
-> 우선순위 큐를 통해 중복되는 비교연산을 없앤다.

N x N 배열을 모두 입력 받고 맨 아래에 있는 N개의 원소를 우선순위 큐에 삽입한다. (최대 힙)
우선순위 큐에서 하나씩 뽑을때마다 cnt를 늘린다. 만약 cnt가 N이라면 원하는 수 찾음
그 후 뽑은 원소 위에 있는 원소를 우선순위큐에 넣는다.

이 과정을 찾고자 하는 원소를 찾을 때까지 반복한다.
## 복기
딱히 없음
---

# 한 줄로 서기
## 사고 흐름
N이 10 미만이라 브루트포스로도 풀 수 있는 문제겠지만
규칙을 발견하면 매우 쉬운 문제

1. N 사이즈의 배열을 선언하고 이를 A라고 하자
2. i: 1~N까지 반복
   * 입력을 하나씩 받아서 현재 받은 입력을 x라고 했을 때, A의 앞에서부터 x번째 빈공간에 i를 넣어준다.

##복기
입력을 받아서 배열에 저장해놓을 필요 없이 그때 그때 입력을 받아 처리하여 소량의 메모리 절약 가능

---

# DFS와 BFS
## 사고 흐름
단순 BFS, DFS 구현 문제
차이점은 정점의 번호가 낮은 순으로 순회한다는 것 -> 인접 리스트 형식으로 그래프를 입력받고 이웃 정점을 오름차순으로 정렬해준 뒤에 기존에 구현하던 BFS와 DFS로 구현해주면 됨 
## 복기
없음.

---

# 쉬운 최단거리
## 사고 흐름
가로와 세로로만 움직일 수 있으므로 갱신되는 거리는 최대1 -> priority queue 필요없이 BFS로 순회시 자동으로 최단거리순으로 탐색하게 됨
visited 배열 대신 거리를 기록할 dist 배열을 선언하고 이를 visited처럼 활용하면 됨
## 복기
N x M 크기의 dist배열을 새로 선언할 필요 없이 기존에 입력받은 2차원 행렬을 재사용하여 메모리를 절반 절약할 수 있음