### PR TITLE
1260 DFS와 BFS & 14940 쉬운 최단거리

### DIFF
--- a/박민수/1260_DFS와BFS.java
+++ b/박민수/1260_DFS와BFS.java
@@ -1,0 +1,93 @@
+package SoraeCodingMasters.BOJ1260;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 1260번
+ * DFS와 BFS
+ * 2024-02-21
+ * 시간 제한 : 2초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int N, M, V; // 1 <= N <= 1,000 / 1 <= M <= 10,000
+    static List<Integer>[] graph;
+    static boolean[] visited;
+    static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        V = Integer.parseInt(st.nextToken());
+
+        visited = new boolean[N + 1];
+        graph = new ArrayList[N + 1];
+        for(int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for(int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+
+            graph[s].add(e);
+            graph[e].add(s);
+        }
+
+        // 오름차순 정렬
+        for(int i = 1; i <= N; i++) {
+            Collections.sort(graph[i]);
+        }
+
+        dfs(V);
+        Arrays.fill(visited, false);
+        sb.append("\n");
+        bfs(V);
+
+        System.out.println(sb);
+    }
+
+    public static void dfs(int start) {
+        visited[start] = true;
+        sb.append(start).append(" ");
+
+        for (int i = 0; i < graph[start].size(); i++) {
+            int next = graph[start].get(i);
+            if (!visited[next]) {
+                dfs(next);
+            }
+        }
+    }
+
+    public static void bfs(int start) {
+        Queue<Integer> q = new LinkedList<>();
+        visited[start] = true;
+        q.add(start);
+
+        while(!q.isEmpty()) {
+            int current = q.poll();
+            sb.append(current).append(" ");
+
+            for(int i = 0; i < graph[current].size(); i++) {
+                int next = graph[current].get(i);
+                if(!visited[next]) {
+                    visited[next] = true;
+                    q.add(next);
+                }
+            }
+        }
+    }
+}

--- a/박민수/14940_쉬운최단거리.java
+++ b/박민수/14940_쉬운최단거리.java
@@ -1,0 +1,92 @@
+package SoraeCodingMasters.BOJ14940;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 14940번
+ * 쉬운 최단거리
+ * 2024-02-21
+ * 시간 제한 : 1초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int n, m; // 1 <= n, m <= 1,000
+    static int[][] map;
+    static int[][] dir = {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+    static int sx, sy;
+    static int count = 0;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        map = new int[n + 2][m + 2];
+
+        // init
+        for (int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j = 1; j <= m; j++) {
+                int input = Integer.parseInt(st.nextToken());
+                // 시작 지점
+                if (input == 2) {
+                    sx = i;
+                    sy = j;
+                } else if (input == 1) {
+                    map[i][j] = -input;
+                } else {
+                    map[i][j] = input;
+                }
+            }
+        }
+
+        shortestPath();
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= m; j++) {
+                sb.append(map[i][j]).append(" ");
+            }
+            sb.append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    public static void shortestPath() {
+        Deque<Coord> q = new LinkedList<>();
+        map[sx][sy] = count;
+        q.add(new Coord(sx, sy, count + 1));
+
+        while(!q.isEmpty()) {
+            Coord c = q.poll();
+
+            for (int i = 0; i < dir.length; i++) {
+                int nextX = c.x + dir[i][0];
+                int nextY = c.y + dir[i][1];
+
+                if (map[nextX][nextY] == -1) {
+                    map[nextX][nextY] = c.count;
+                    q.add(new Coord(nextX, nextY, c.count + 1));
+                }
+            }
+        }
+    }
+
+    public static class Coord {
+        int x;
+        int y;
+        int count;
+
+        public Coord(int x, int y, int count) {
+            this.x = x;
+            this.y = y;
+            this.count = count;
+        }
+    }
+}


### PR DESCRIPTION
# BOJ 1260 DFS와 BFS

## 사고 흐름

단순하게 DFS와 BFS를 구현하면 되는 문제였다.

방문할 수 있는 정점이 여러 개라는 조건은 인접 리스트에 연결된 정점들을 오름차순으로 정렬해주면 된다.


### 시간 복잡도
정점의 수 N, 간선의 수 M 이라고 할 때 최종 시간 복잡도는 O(N + M) 이다.
## 복기

딱히 없다.

# BOJ 14940 쉬운 최단거리

## 사고 흐름

목표 지점에서 인접한 좌표를 차례대로 탐색 해야하기 때문에 BFS를 구현하면 되는 문제였다.

전체 지도를 입력받을 때 최적화를 위해서 미리 갈 수 없는 땅을 -1로 저장하였다.

또한 인덱스를 벗어나는 예외 처리 대신에 지도의 크기를 2칸 크게 잡아서 코드를 간결하게 하였다.

## 복기

딱히 없다.
