### PR TITLE
20922 겹치는 건 싫어 & 15989 1,2,3 더하기 4

### DIFF
--- a/박민수/15989_1,2,3더하기4.java
+++ b/박민수/15989_1,2,3더하기4.java
@@ -1,0 +1,41 @@
+package SoraeCodingMasters.BOJ15989;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/***
+ * 백준 15989번
+ * 1, 2, 3 더하기 4
+ * 2024-02-22
+ * 시간 제한 : 1초
+ * 메모리 제한 : 512MB
+ */
+
+public class Main {
+    static int T;
+    static int[][] dp;
+    static int N;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        T = Integer.parseInt(br.readLine());
+
+        dp = new int[10001][4];
+        dp[1][1] = dp[2][1] = dp[2][2] = dp[3][1] = dp[3][2] = dp[3][3] = 1;
+
+        for (int i = 4; i <= 10000; i++) {
+            dp[i][1] = dp[i - 1][1];
+            dp[i][2] = dp[i - 2][1] + dp[i - 2][2];
+            dp[i][3] = dp[i - 3][1] + dp[i - 3][2] + dp[i - 3][3];
+        }
+
+        StringBuilder sb = new StringBuilder();
+        while(T-- > 0) {
+            N = Integer.parseInt(br.readLine());
+            sb.append(dp[N][1] + dp[N][2] + dp[N][3]).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+
+}

--- a/박민수/20922_겹치는건싫어.java
+++ b/박민수/20922_겹치는건싫어.java
@@ -1,0 +1,62 @@
+package SoraeCodingMasters.BOJ20922;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 20922번
+ * 겹치는 건 싫어
+ * 2024-02-22
+ * 시간 제한 : 1초
+ * 메모리 제한 : 1024MB
+ */
+
+public class Main {
+    static int N; // 1 <= N <= 200,000
+    static int K; // 1 <= K <= 100
+    static int[] sequence;
+    static int s,e;
+    static int answer = Integer.MIN_VALUE;
+    static Map<Integer, Integer> section;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        sequence = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            sequence[i] = Integer.parseInt(st.nextToken());
+        }
+
+        section = new HashMap<>();
+
+        s = 0;
+        e = 0;
+        while(e < N) {
+            int value = sequence[e];
+            int count = section.getOrDefault(value, 0);
+            if (count < K) {
+                section.put(value, count + 1);
+                e++;
+            } else {
+                int v = sequence[s];
+                section.put(v, section.get(v) - 1);
+                s++;
+            }
+            answer = Math.max(answer, e - s);
+        }
+
+        System.out.println(answer);
+    }
+
+}


### PR DESCRIPTION
# BOJ 20922 겹치는 건 싫어

## 사고 흐름

가장 먼저 '**연속된 구간 내에서 특정 요소의 개수가 K개를 초과**' 하면 안되기 때문에 구간이 정해졌을 때 그 구간 내의 요소의 개수를 파악해야겠다고 생각하였다.

모든 구간에 대하여 처리를 하기에는 O(N^2)의 시간 복잡도가 필요하고 N의 범위가 (1 <= N <= 200,000) 크기 때문에 불가능하였다.

따라서, 선형 시간 내에 처리하기 위해서 투 포인터를 사용해야 한다.

왼쪽, 오른쪽 포인터를 맨 앞에 배치하고 오른쪽 포인터를 하나씩 늘려가다 특정 요소의 개수가 K를 초과하면 왼쪽 포인터를 늘리면서 특정 요소의 개수가 K 이하가 되도록 제거해주면 된다.

## 복기

특정 조건을 만족하는 부분 구간을 구하는 문제를 만난다면 투 포인터를 고려해야겠다.

# BOJ 15989 1, 2, 3 더하기 4

## 사고 흐름

가장 먼저, 이전에 게산했던걸 이용해야 한다는 점에서 이 문제가 DP로 해결해야함을 느꼈다.

마지막 더해지는 숫자가 1, 2, 3 으로 나뉘어야 하는 것 까지 생각했지만, 이를 저장할 자료구조와 점화식을 만드는 데에서 막혔다.

이 문제는 다음에 꼭 다시 한 번 풀어보겠습니다.

## 복기

더하는 순서를 오름차순으로 정렬했다면 좀 더 직관적이게 풀었을 것 같다.