### PR TITLE
20922 겹치는 건 싫어 & 15989 1, 2, 3 더하기 4 

### DIFF
--- a/김남주/1446_지름길.cpp
+++ b/김남주/1446_지름길.cpp
@@ -1,0 +1,59 @@
+#include <iostream>
+#include <algorithm>
+#include <set>
+#include <queue>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+typedef pair<int,int> pii;
+const int INF=1e9;
+
+#define MAX 10'000
+vector<pii> g[MAX+1];
+int dist[MAX+1];
+int n,d;
+
+int main() {
+    fastio;
+    // read_input;
+    cin>>n>>d;
+
+    int a,b,c;
+    set<int,greater<int>> nodeset;
+    for (int i=0;i<n;i++) {
+        cin>>a>>b>>c;
+        g[a].push_back({c,b});
+        nodeset.insert(a);
+    }
+    nodeset.insert(d);
+
+    fill(&dist[0],&dist[MAX+1],INF);
+    priority_queue<pii,vector<pii>,greater<pii>> pq;
+    dist[0]=0;
+    pq.push({0,0});
+    while(!pq.empty()) {
+        auto [cc,cp]=pq.top();
+        pq.pop();
+        if (cc>dist[cp]) continue;
+        if (cp==d) {
+            cout<<cc;
+            return 0;
+        }
+
+        for (auto& next: nodeset) {
+            if (next<cp) break;
+            if (dist[next]<=cc+next-cp) continue;
+            dist[next]=cc+next-cp;
+            pq.push({dist[next],next});
+        }
+
+        for (auto& [nc,np]:g[cp]) {
+            if (dist[np]<=cc+nc || np>d) continue;
+            dist[np]=cc+nc;
+            pq.push({dist[np],np});
+        }
+    }
+}

--- a/김남주/15989_1,2,3더하기4.cpp
+++ b/김남주/15989_1,2,3더하기4.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <queue>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+int n;
+
+int dp2[10001];
+int dp3[10001];
+
+int main() {
+	fastio;
+	//read_input;
+	int tc;
+	cin >> tc;
+	while (tc--) {
+		cin >> n;
+		memset(dp2, 0, sizeof(int) * (n + 1));
+		memset(dp3, 0, sizeof(int) * (n + 1));
+		
+		dp2[2] = 1;
+		dp2[3] = 1, dp3[3] = 1;
+		for (int i = 4;i <= n;i++) {
+			dp2[i] += (dp2[i - 2] + 1);
+			dp3[i] += (dp2[i-3] + dp3[i - 3] + 1);
+		}
+		cout << 1 + dp2[n] + dp3[n] << '\n';
+	}
+}

--- a/김남주/20922_겹치는건싫어.cpp
+++ b/김남주/20922_겹치는건싫어.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <queue>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+#define MAX 200'000
+#define MAP 100'000
+
+int n, k;
+int a[MAX],pre[MAX];
+int map[MAP + 1];
+int dp[MAP + 1];
+
+int main() {
+	fastio;
+	//read_input;
+	cin >> n >> k;
+	for (int i = 0;i < n;i++) {
+		cin >> a[i];
+		pre[i] = map[a[i]];
+		map[a[i]] = i;
+	}
+	
+	int cur_s = 0;
+	int ans = 0;
+	for (int i = 0;i < n;i++) {
+		if (++dp[a[i]] > k) {
+			int next_s = i;
+			for (int j = 0;j < k;j++) {
+				next_s = pre[next_s];
+			}
+			next_s++;
+			for (int j = cur_s;j < next_s;j++) dp[a[j]]--;
+			cur_s = next_s;
+		}
+		ans = max(ans, i - cur_s + 1);
+	}
+	cout << ans;
+}


### PR DESCRIPTION
# 겹치는 건 싫어
## 사고 흐름
입력의 크기가 최대 200,000이므로 O(N)안에 들어오거나 O(NlgN) 안에 들어와야 된다고 생각
모든 경우를 따지는 건 불가능 -> DP의 방식으로 접근해보자
왜 DP로 접근할 생각을 했을까? 배열을 순회하면서 몇개가 겹치는지 체크하면서 중복된 계산을 피할 수 있을 것이라 생각

입력 수열의 각 자리수의 전 인덱스를 저장하고 만약 겹치는게 K개 초과하게 된다면 해당 인덱스를 K번 만큼 뒤로가서 그 뒤의 인덱스에서 부분 수열을 시작하는 방식으로 풀었음.
## 복기
그러나 실제로 푼 풀이는 DP라고 보기 조금 어려운 듯함. 중복되는 부분문제를 빠르게 해결한다는 DP의 이점을 사용한 것 같진 않다.
그러나 시간안에 잘들어왔고 푼 풀이는 최대 O(Nf(K))의 시간복잡도를 갖는다. (f(K)라 쓴 이유는 직관적으로 polynomial은 아닐 것 같고 log혹은 그 미만의 증가 속도를 가지는 함수일 것 같음)

이 문제에서 요구하는 정석 풀이는 투포인터를 활용하는 것이었다.
투포인터를 쓸 생각을 하지 못했는데, 이런 문제와 같이 연속되는 구간(이 문제에서는 연속 부분 수열을 찾는 것)에 대한 답을 찾는 경우에는 투포인터를 사용할 수 있다는 것을 생각해보면 좋을 것 같다.


---


# 1, 2, 3 더하기 4 
## 사고 흐름
문제를 제대로 읽지 않고 전형적인 브루트포스 문제일거라 짐작하고 브루트포스로 풀었다 시간 초과가 발생하였다.
입력이 최대 (n=10,000) 이므로 브루트포스로 접근할 시에 시간복잡도는 매우 크다 (순서를 고려하지 않으므로 3^n은 아님)

300을 만드는 경우의수는 100을 만드는 경우의수와 200의 합처럼 볼 수 있는 것 처럼 중복되는 부분문제를 최적화 할 수 있다. 
따라서 DP로 접근하였고 1,2,3의 순서를 고려하지 않으므로 작은 수부터 더해준다고 생각해서 DP[10000][3]과 같은 테이블을 만들었다.
여기서 1을 더해서 만드는 경우의 수는 모두 1이므로 이 부분은 따로 테이블을 만들지 않아도 되므로 DP[10000][2]로 만들 수 있다.

## 복기
맞힌 사람들의 풀이를 보니
```C
        scanf("%d",&b);
        c=b/3;
        d=0;
        for(y=0;y<=c;y++){
            d+=(b-y*3)/2+1;
        }
```
와 같이 수식을 통해 푼 사람도 있었고 이 풀이가 제일 빨랐다.