### PR TITLE
1446 지름길 & 17615 볼 모으기

### DIFF
--- a/박민수/1446_지름길.java
+++ b/박민수/1446_지름길.java
@@ -1,0 +1,75 @@
+package SoraeCodingMasters.BOJ1446;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 1446번
+ * 지름길
+ * 2024-02-23
+ * 시간 제한 : 2초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int N, D; // 1 <= N <= 12 / 1 <= D <= 10,000
+    static int[] dp; // index 까지의 최단 거리
+    static List<Path> paths;
+    static int to, from, w;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        D = Integer.parseInt(st.nextToken());
+
+        dp = new int[D + 1];
+        for (int i = 1; i <= D; i++) {
+            dp[i] = i;
+        }
+
+        paths = new ArrayList<>();
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            to = Integer.parseInt(st.nextToken());
+            from = Integer.parseInt(st.nextToken());
+            w = Integer.parseInt(st.nextToken());
+            paths.add(new Path(to, from, w));
+        }
+
+        Path prev = new Path(0, 0, 0);
+        for (Path path : paths) {
+            if ((path.from - path.to) < path.w || path.from > D) continue;
+            dp[path.from] = Math.min(dp[path.from], Math.min(dp[prev.from] + (path.to - prev.from) + path.w, dp[path.to] + path.w));
+            for (int j = path.from + 1; j <= D; j++) {
+                dp[j] = Math.min(dp[j], dp[j - 1] + 1);
+            }
+        }
+
+        System.out.println(dp[D]);
+    }
+
+    public static class Path implements Comparable<Path>{
+        int to;
+        int from;
+        int w;
+
+        public Path(int to, int from, int w) {
+            this.to = to;
+            this.from = from;
+            this.w = w;
+        }
+
+        @Override
+        public int compareTo(Path o) {
+            return this.to - o.to;
+        }
+    }
+}

--- a/박민수/17615_볼모으기.java
+++ b/박민수/17615_볼모으기.java
@@ -1,0 +1,66 @@
+package SoraeCodingMasters.BOJ17615;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/***
+ * 백준 17615번
+ * 볼 모으기
+ * 2024-02-23
+ * 시간 제한 : 1초
+ * 메모리 제한 : 512MB
+ */
+
+public class Main {
+    static int N; // 1 <= N <= 500,000
+    static char[] balls;
+    static int blue, red; // 연속된 공의 개수
+    static int answer = Integer.MAX_VALUE;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        balls = br.readLine().toCharArray();
+
+        // 각 공의 수 세기
+        for (int i = 0; i < N; i++) {
+            if (balls[i] == 'B') blue++;
+            else red++;
+        }
+
+        // 빨간 공을 왼쪽으로 몰기 -> 왼쪽에 있는 빨간 공 세야됨
+        int count = 0;
+        for (int i = 0; i < N; i++) {
+            if (balls[i] != 'B') count++;
+            else break;
+        }
+        answer = Math.min(answer, red - count);
+
+        // 빨간 공을 오른쪽으로 몰기 -> 오른쪽에 있는 빨간 공 세야됨
+        count = 0;
+        for (int i = N - 1; i >= 0; i--) {
+            if (balls[i] != 'B') count++;
+            else break;
+        }
+        answer = Math.min(answer, red - count);
+
+        // 파란 공을 왼쪽으로 몰기 -> 왼쪽에 파란 빨간 공 세야됨
+        count = 0;
+        for (int i = 0; i < N; i++) {
+            if (balls[i] != 'R') count++;
+            else break;
+        }
+        answer = Math.min(answer, blue - count);
+
+        // 파란 공을 오른쪽으로 몰기 -> 오른쪽에 있는 파란 공 세야됨
+        count = 0;
+        for (int i = N - 1; i >= 0; i--) {
+            if (balls[i] != 'R') count++;
+            else break;
+        }
+        answer = Math.min(answer, blue - count);
+
+        System.out.println(answer);
+    }
+
+}


### PR DESCRIPTION
# BOJ 1446 지름길

## 사고 흐름

일차원 DP 배열을 선언하고 해당 인덱스 길이까지의 최단거리를 저장하는 방식으로 접근하였다.

가장 가까운 지름길부터 갱신해나가야 하기 때문에 지름길의 출발점을 기준으로 오름차순으로 정렬하였다. (다익스트라 ?)

지름길 중 도착점이 고속도로 밖에 있거나 지름길을 탔을 경우 오히려 멀어지는 지름길을 제외였다.

지름길을 탔을 때와 타지 않았을 때의 최솟값으로 최단거리를 갱신하여 해결하였다.

### 시간 복잡도

최종 시간 복잡도는 O(N \* D) 이다.

## 복기

다익스트라와 DP의 개념이 섞인 듯한 문제 같다.

# BOJ 17615_볼 모으기

## 사고 흐름

처음 문제를 보고 구현이거나 그리디 문제일 것이라고 생각하였다.

공을 한쪽으로 몰기 위해서 2가지를 생각하였다.
1. 어떤 색의 공을 옮길지
2. 방향을 어디로 옮길지

따라서, 왼쪽으로 빨간 공 파란 공 몰기 (2가지) / 오른쪽으로 빨간 공 파란 공 몰기 (2가지) 해서 총 4가지 경우 중 최소 값을 구하면 된다.

나는 머리가 굳어서 그런지 옮기는 횟수 구하기에서 막혔다.........


## 복기

구현적인 부분을 어떻게 극복해야할 지가 고민이다......