### PR TITLE
2531 회전 초밥 & 1522 문자열 교환

### DIFF
--- a/김남주/1522_문자열교환.cpp
+++ b/김남주/1522_문자열교환.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <string>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+int main() {
+	fastio;
+	//read_input;
+	string s;
+	cin >> s;
+	int len = 0;
+	for (auto& c : s) {
+		if (c == 'a') len++;
+	}
+	
+	int ans = 1e9;
+	int a_n = 0, b_n = 0;
+	for (int i = 0;i < len;i++) {
+		if (s[i] == 'a') a_n++;
+		else b_n++;
+	}
+	ans = min(ans, b_n);
+	if (!ans) { cout << 0; return 0; }
+	int sn = s.size();
+	for (int i = len;i < len+sn-1 ;i++) {
+		if (s[(i - len)%sn] == 'a') a_n--;
+		else b_n--;
+		if (s[i % sn] == 'a') a_n++;
+		else b_n++;
+		ans = min(ans, b_n);
+		if (!ans) { cout << 0; return 0; }
+	}
+	cout << ans;
+}

--- a/김남주/2531_회전초밥.cpp
+++ b/김남주/2531_회전초밥.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <queue>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+int n, d, k, c;
+int dishes[30'000];
+int eat[3000+1];
+
+int main() {
+	fastio;
+	//read_input;
+
+	cin >> n >> d >> k >> c;
+	for (int i = 0;i < n;i++) cin >> dishes[i];
+	
+	int cnt = 0, ans = 0;
+	for (int i = 0;i < k;i++) {
+		if (eat[dishes[i]]++==0) cnt++;
+	}
+	if (!eat[c]) cnt++;
+	ans = cnt;
+	if (!eat[c]) cnt--;
+	for (int i = k;i < n+k-1;i++) {
+		if (--eat[dishes[(i - k) % n]] == 0) cnt--;
+		if (eat[dishes[i % n]]++ == 0) cnt++;
+		if (!eat[c]) cnt++;
+		ans = max(ans, cnt);
+		if (!eat[c]) cnt--;
+	}
+	cout << ans;
+}


### PR DESCRIPTION
# 회전 초밥

## 사고 흐름
1. 일정 길이 K의 연속된 초밥을 먹고 해당 초밥 종류의 최대값을 구하는 문제 -> 슬라이딩 윈도우
2. 쿠폰으로 인해 종류가 추가되는지 안되는지 따로 구현해줘야 함 -> 구현 

기본적으로 모든 경우를 검사해야하는 브루트포스 문제임
그러나 입력 시퀀스의 일정 부분 길이를 검사하는 문제이므로 #11 문제처럼 슬라이딩 윈도우로 O(N)안에 처리할 수 있음

원으로 이루어져있으므로 배열의 끝과 처음이 붙어있다고 생각하고 모듈러 연산을 통해 구현을 해야함.
+
2번 부분은 실수하기 쉬울 것 같아서 특히 꼼꼼히 구현해야 겠다고 생각했고 다 구현한 뒤에 몇가지 테스트 케이스에 대해 디버거르 돌려봄

## 복기
#11 문제의 이동평균을 구하는 것과 매우 비슷한 문제였음.

브루트 포스 + 입력 시퀀스의 일정 구간을 탐색한다 -> 슬라이딩 윈도우

---

# 문자열 교환

## 사고 흐름
최소 교환 횟수 -> 문제를 보자마자 브루트포스 혹은 그리디의 방식으로 접근해야 겠다고 생각함.
근데 브루트포스로 구현하다고 하면 어떤 위치의 'b'를 바꿔야하는지 재귀로 어떻게 구현해야 되는지 안떠올랐음
그래서 그리디로 생각해봤는데 어떤 것이 최적의 선택일지 전혀 생각이 안났음

그래서 사실 알고리즘 분류칸의 힌트를 봤다
* 브루트포스
* 슬라이딩 윈도우

라고 하길래 곰곰히 생각해봤을때 위의 회전초밥 문제와 거의 비슷함을 알 수 있었다.
알파벳 a의 개수 만큼을 구간의 길이로 결정하고, 그 구간에 a가 모두 놓였을 때를 가정하고 b의 교환 횟수를 검사하는 것
-> 이때 교환 횟수는 구간 내의 알파벳 b의 개수와 같다.
따라서 회전 초밥 문제와 거의 비슷하게 구현하고 그저 구간 내의 알파벳 b의 개수의 최솟값을 구하면 되는 문제였다.

## 복기
문제를 보고 브루트포스로 풀어야 겠다고 생각은 했지만 'a가 연속하기 위한 교환 횟수의 최솟값' 이라는 말에 꽂혀 
구간 내의 b의 개수가 교환 횟수가 될 것이라는 생각을 못했었다.

'연속해서 존재한다' 등의 워딩을 보고 위의 아이디어를 떠올려보자.

