### PR TITLE
2531 회전초밥 & 1522 문자열 교환 

### DIFF
--- a/박민수/1522_문자열교환.java
+++ b/박민수/1522_문자열교환.java
@@ -14,7 +14,7 @@ import java.io.InputStreamReader;
 
 public class Main {
     static char[] input;
-    static int a, b;
+    static int a;
     static int len;
     static int total = Integer.MAX_VALUE;
     public static void main(String[] args) throws IOException {
@@ -22,47 +22,19 @@ public class Main {
         input = br.readLine().toCharArray();
         len = input.length;
 
+        // a의 개수 세기
         for (int i = 0; i < len; i++) {
             if (input[i] == 'a') a++;
-            else b++;
         }
 
-        int la, ra, lb, rb;
         int l = 0;
         while(l < len) {
-            la = ra = lb = rb = 0;
-            // a를 왼쪽으로 몰기
-            for (int i = l; i < l + len; i++) {
-                if (input[i % len] == 'a') la++;
-                else break;
+            int b = 0;
+            // a 범위 내에서 교환할 b 개수 찾기
+            for (int i = l; i < l + a; i++) {
+                if (input[i % len] == 'b') b++;
             }
-            la = a - la;
-            total = Math.min(total, la);
-
-            // a를 오른쪽으로 몰기
-            for (int i = l + len - 1; i >= l; i--) {
-                if (input[i % len] == 'a') ra++;
-                else break;
-            }
-            ra = a - ra;
-            total = Math.min(total, la);
-
-            // b를 왼쪽으로 몰기
-            for (int i = l; i < l + len; i++) {
-                if (input[i % len] == 'b') lb++;
-                else break;
-            }
-            lb = b - lb;
-            total = Math.min(total, lb);
-
-            // a를 오른쪽으로 몰기
-            for (int i = l + len - 1; i >= l; i--) {
-                if (input[i % len] == 'b') rb++;
-                else break;
-            }
-            rb = b - rb;
-            total = Math.min(total, rb);
-
+            total = Math.min(total, b);
             l++;
         }
 

--- a/박민수/1522_문자열교환.java
+++ b/박민수/1522_문자열교환.java
@@ -1,0 +1,72 @@
+package SoraeCodingMasters.BOJ1522;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/***
+ * 백준 1522번
+ * 문자열 교환
+ * 2024-02-24
+ * 시간 제한 : 2초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static char[] input;
+    static int a, b;
+    static int len;
+    static int total = Integer.MAX_VALUE;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        input = br.readLine().toCharArray();
+        len = input.length;
+
+        for (int i = 0; i < len; i++) {
+            if (input[i] == 'a') a++;
+            else b++;
+        }
+
+        int la, ra, lb, rb;
+        int l = 0;
+        while(l < len) {
+            la = ra = lb = rb = 0;
+            // a를 왼쪽으로 몰기
+            for (int i = l; i < l + len; i++) {
+                if (input[i % len] == 'a') la++;
+                else break;
+            }
+            la = a - la;
+            total = Math.min(total, la);
+
+            // a를 오른쪽으로 몰기
+            for (int i = l + len - 1; i >= l; i--) {
+                if (input[i % len] == 'a') ra++;
+                else break;
+            }
+            ra = a - ra;
+            total = Math.min(total, la);
+
+            // b를 왼쪽으로 몰기
+            for (int i = l; i < l + len; i++) {
+                if (input[i % len] == 'b') lb++;
+                else break;
+            }
+            lb = b - lb;
+            total = Math.min(total, lb);
+
+            // a를 오른쪽으로 몰기
+            for (int i = l + len - 1; i >= l; i--) {
+                if (input[i % len] == 'b') rb++;
+                else break;
+            }
+            rb = b - rb;
+            total = Math.min(total, rb);
+
+            l++;
+        }
+
+        System.out.println(total);
+    }
+
+}

--- a/박민수/2531_회전초밥.java
+++ b/박민수/2531_회전초밥.java
@@ -1,0 +1,54 @@
+package SoraeCodingMasters.BOJ2531;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 2531번
+ * 회전 초밥
+ * 2024-02-24
+ * 시간 제한 : 1초
+ * 메모리 제한 : 256MB
+ */
+
+public class Main {
+    static int N; // 2 <= N <= 30,000
+    static int d; // 2 <= d <= 3,000
+    static int k; // 2 <= k <= 3,000
+    static int c; // 1 <= c <= d
+    static int[] sushi;
+    static Set<Integer> sort;
+    static int total = Integer.MIN_VALUE;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        d = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+
+        sushi = new int[N];
+        for (int i = 0; i < N; i++) {
+            sushi[i] = Integer.parseInt(br.readLine());
+        }
+
+        int l = 0;
+
+        while(l < N) {
+            sort = new HashSet<>();
+            for (int i = l; i < l + k; i++) {
+                sort.add(sushi[(i % N)]);
+            }
+            sort.add(c);
+            total = Math.max(total, sort.size());
+            l++;
+        }
+
+        System.out.println(total);
+    }
+
+}


### PR DESCRIPTION
# BOJ 2531_회전초밥

## 사고 흐름

처음 문제를 보고 슬라이딩 윈도우 알고리즘을 생각했다.

k범위 만큼의 초밥을 볼 때, 중복되는 초밥이 있으므로 Hash Set을 이용하여 중복을 제거하였다.

연속해서 초밥을 먹을 때 가장 다양한 가지 수의 초밥을 먹을 수 있으므로 항상 쿠폰을 Hash Set에 넣어서 종류 가지 수를 갱신해준다.

## 복기 

while 문 index 계산을 실수해서 틀렸는데, 사소한 실수를 줄이도록 해야겠다.

입력의 크기가 커진다면 K 범위 만큼 반복문을 돌지 않고 `앞의 원소 제거, 뒤의 원소 삽입`으로 연산을 줄여야할 것 같다. 

# BOJ 1522\_문자열교환

## 사고 흐름

문제를 읽고 처음 들었던 생각은 [볼 모으기 문제](https://boj.kr/17615)와 비슷한 문제라고 생각하였다.

문자열이 순환된다는 점에서 슬라이딩 윈도우 알고리즘 방식으로 전체 문자열의 길이를 범위로 잡고 하나씩 옮겨가며 `볼 모으기` 문제와 유사하게 접근하였다.

그러나, 문제점은 문자를 옮기는 것이 아닌 "교환"하는 것이었다.

슬라이딩 윈도우 알고리즘을 적용하되, 문자열 내에 a의 갯수를 범위로 잡아서 해당 범위 내 b의 개수가 가장 적을 때를 구하면 된다.

## 복기

문제를 풀다가 막힐 때, 주의를 환기 시킬 필요가 있다.
