### PR TITLE
20055 컨베이어 벨트 위의 로봇

### DIFF
--- a/김남주/20055_컨베이어벨트위의로봇.cpp
+++ b/김남주/20055_컨베이어벨트위의로봇.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 int n,k;
 int hp[201];
-int num[201];
+bool num[201];
 
 int main() {
     fastio;
@@ -20,6 +20,7 @@ int main() {
     
     int ans=1;
     int up_pos=0,down_pos=n-1;
+    int cur_k=0;
     while (true) {
         up_pos=up_pos?(up_pos-1):(2*n-1);
         down_pos=down_pos?(down_pos-1):(2*n-1);
@@ -29,19 +30,19 @@ int main() {
             if (idx>=(int)robot_pos.size()) break;
             auto& p=robot_pos[idx];
             if (p==down_pos) {
-                num[p]--;
+                num[p]=false;
                 robot_pos.pop_front();
                 continue;
             }
             int next_pos=(p+1)%(2*n);
             if (num[next_pos]==0 && hp[next_pos]>0) {
-                num[p]--;
-                hp[next_pos]--;
-                num[next_pos]++;
+                num[p]=false;
+                if(--hp[next_pos]==0) cur_k++;
+                num[next_pos]=true;
                 p=next_pos;
             }
             if (p==down_pos) {
-                num[p]--;
+                num[p]=false;
                 robot_pos.pop_front();
                 continue;
             }
@@ -49,12 +50,8 @@ int main() {
         }
         if (hp[up_pos]>0) {
             robot_pos.push_back(up_pos);
-            num[up_pos]++;
-            hp[up_pos]--;
-        }
-        int cur_k=0;
-        for (int i=0;i<2*n;i++) {
-            if (!hp[i]) cur_k++;
+            num[up_pos]=true;
+            if(--hp[up_pos]==0)cur_k++;
         }
         if (cur_k>=k) break;
         ans++;

--- a/김남주/20055_컨베이어벨트위의로봇.cpp
+++ b/김남주/20055_컨베이어벨트위의로봇.cpp
@@ -6,12 +6,11 @@
 using namespace std;
 
 int n,k;
-int hp[201];
+int hp[201], pos[201];
 bool num[201];
 
 int main() {
     fastio;
-    deque<int> robot_pos;
     cin>>n>>k;
     
     for (int i=0;i<2*n;i++) {
@@ -21,40 +20,38 @@ int main() {
     int ans=1;
     int up_pos=0,down_pos=n-1;
     int cur_k=0;
+    int r_n=0;
     while (true) {
         up_pos=up_pos?(up_pos-1):(2*n-1);
         down_pos=down_pos?(down_pos-1):(2*n-1);
         
-        int idx=0;
-        while (true) {
-            if (idx>=(int)robot_pos.size()) break;
-            auto& p=robot_pos[idx];
+        int x=0;
+        for (int i=0;i<r_n;i++) {
+            auto& p=pos[i];
             if (p==down_pos) {
                 num[p]=false;
-                robot_pos.pop_front();
                 continue;
             }
             int next_pos=p==2*n-1?0:p+1;
-            if (num[next_pos]==0 && hp[next_pos]>0) {
+            if (!num[next_pos] && hp[next_pos]>0) {
                 num[p]=false;
                 if(--hp[next_pos]==0) cur_k++;
+                if (next_pos==down_pos) {
+                    continue;
+                }
+
                 num[next_pos]=true;
-                p=next_pos;
-            }
-            if (p==down_pos) {
-                num[p]=false;
-                robot_pos.pop_front();
-                continue;
-            }
-            idx++;
+                pos[x++]=next_pos;
+            } else pos[x++]=p;
         }
         if (hp[up_pos]>0) {
-            robot_pos.push_back(up_pos);
+            pos[x++]=up_pos;
             num[up_pos]=true;
             if(--hp[up_pos]==0)cur_k++;
         }
         if (cur_k>=k) break;
         ans++;
+        r_n=x;
     }
     cout<<ans;
 }

--- a/김남주/20055_컨베이어벨트위의로봇.cpp
+++ b/김남주/20055_컨베이어벨트위의로봇.cpp
@@ -34,7 +34,7 @@ int main() {
                 robot_pos.pop_front();
                 continue;
             }
-            int next_pos=(p+1)%(2*n);
+            int next_pos=p==2*n-1?0:p+1;
             if (num[next_pos]==0 && hp[next_pos]>0) {
                 num[p]=false;
                 if(--hp[next_pos]==0) cur_k++;

--- a/김남주/20055_컨베이어벨트위의로봇.cpp
+++ b/김남주/20055_컨베이어벨트위의로봇.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <deque>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+
+using namespace std;
+
+int n,k;
+int hp[201];
+int num[201];
+
+int main() {
+    fastio;
+    deque<int> robot_pos;
+    cin>>n>>k;
+    
+    for (int i=0;i<2*n;i++) {
+        cin>>hp[i];
+    }
+    
+    int ans=1;
+    int up_pos=0,down_pos=n-1;
+    while (true) {
+        up_pos=up_pos?(up_pos-1):(2*n-1);
+        down_pos=down_pos?(down_pos-1):(2*n-1);
+        
+        int idx=0;
+        while (true) {
+            if (idx>=(int)robot_pos.size()) break;
+            auto& p=robot_pos[idx];
+            if (p==down_pos) {
+                num[p]--;
+                robot_pos.pop_front();
+                continue;
+            }
+            int next_pos=(p+1)%(2*n);
+            if (num[next_pos]==0 && hp[next_pos]>0) {
+                num[p]--;
+                hp[next_pos]--;
+                num[next_pos]++;
+                p=next_pos;
+            }
+            if (p==down_pos) {
+                num[p]--;
+                robot_pos.pop_front();
+                continue;
+            }
+            idx++;
+        }
+        if (hp[up_pos]>0) {
+            robot_pos.push_back(up_pos);
+            num[up_pos]++;
+            hp[up_pos]--;
+        }
+        int cur_k=0;
+        for (int i=0;i<2*n;i++) {
+            if (!hp[i]) cur_k++;
+        }
+        if (cur_k>=k) break;
+        ans++;
+    }
+    cout<<ans;
+}


### PR DESCRIPTION
## 사고 흐름
문제를 읽으면서 어떤 정보를 어떤 자료구조에 저장해야 하는지 생각

1. 컨베이어 벨트의 내구도
2. 컨베이어 벨트 위에 로봇이 있는가
3. 로봇의 위치

위 3개 모두 선형 자료구조 (배열, 스택, 큐 등)에 저장 가능
3번 같은 경우는 먼저 올라온 로봇이 먼저 내려가는 선입선출의 구조를 가지므로 덱(deque)을 사용해야 한다고 생각

1번과 2번은 컨베이어 벨트의 최대 번호 2 x N (200) 크기의 배열에 저장

이런 문제는 실수 하기 쉬우므로 최적화 할 수 있는 부분보다 문제에 명시된 단계를 정확하게 구현하는데 집중함
1. 컨베이어 벨트가 회전한다
   * 실제 컨베이어 벨트를 하나씩 밀면 O(N)이 소요되므로 올리는 위치와 내리는 위치를 1씩 당겨줌 -> O(1)
2. 로봇이 움직일 수 있으면 움직인다.
   * 덱에 저장한 로봇을 순서대로 순회함 -> 만약 현재 로봇이 내려간다면 해당 로봇을 `pop_front`
3. 올리는 칸에 로봇을 올림
   * 내구도를 확인하고 올릴 수 있으면 로봇을 덱에 `push_back`
4. 2 x N 개의 컨베이어 벨트의 내구도를 검사해서 0인 벨트가 k개 이상이라면 break

## 복기
내가 푼 풀이에서는 최적화 할 포인트가 크게 3개 있었음

1. 4번 과정에서 매 단계마다 마지막에 for 문을 통해 검사하는 것이 아니라 내구도가 0이 되면 그때마다 값을 올려줌 : 84ms -> 64ms
2. 인덱스 2N-1 다음에 0이 되야 하므로 모듈러 연산을 썼었는데 이는 무거운 연산이므로 삼항 연산으로 대체 : 64ms -> 40ms
   * `x=(x+1)%(2*n)` => `x = x==2n-1 ? 0 : x+1`
3. STL에 있는 deque를 사용하지 않고 하나의 배열을 재사용하여 비슷하게 구현 : 40ms -> 16ms
   * 단계 마다`int x=0` 변수 선언, 내리는 로봇이면 continue, 컨베이어 벨트에 아직 있다면 'arr[x++]=val' 단계의 마지막에 로봇의 개수 업데이트 `r_n=x`
 
약 80%의 시간 감소
![image](https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/55823958/7ee561ac-be92-42aa-a35c-9f1f95026da1)

