### PR TITLE
16234 인구 이동

### DIFF
--- a/박민수/16234_인구이동.java
+++ b/박민수/16234_인구이동.java
@@ -27,7 +27,7 @@ public class Main {
     static int[][] lands;
     static boolean[][] visited;
     static int day = 0;
-    static List<List<Location>> unions;
+    static List<Location> union;
 
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -50,31 +50,20 @@ public class Main {
             // 매 회차당 초기화
             boolean stop = true;
             visited = new boolean[N][N];
-            unions = new ArrayList<>();
-
             // 연합 만들기
             for (int x = 0; x < N; x++) {
                 for (int y = 0; y < N; y++) {
                     if (!visited[x][y]) {
-                        bfs(x, y);
-                    }
-                }
-            }
+                        int sum = bfs(x, y);
 
-            for (List<Location> union : unions) {
-                if (union.size() > 1) {
-                    stop = false;
-
-                    // 연합 인구 계산
-                    int total = 0;
-                    for (Location l : union) {
-                        total += lands[l.x][l.y];
-                    }
-                    int people = total / union.size();
-
-                    // 연합 인구 이동
-                    for (Location l : union) {
-                        lands[l.x][l.y] = people;
+                        if (union.size() > 1) {
+                            stop = false;
+                            int people = sum / union.size();
+                            // 연합 인구 이동
+                            for (Location l : union) {
+                                lands[l.x][l.y] = people;
+                            }
+                        }
                     }
                 }
             }
@@ -87,14 +76,15 @@ public class Main {
 
         System.out.println(day);
     }
-    public static void bfs(int x, int y) {
-        unions.add(new ArrayList<>());
-        unions.get(unions.size() - 1).add(new Location(x, y));
+    public static int bfs(int x, int y) {
+        union = new ArrayList<>();
+        union.add(new Location(x, y));
 
         Queue<Location> q = new LinkedList<>();
         q.add(new Location(x, y));
         visited[x][y] = true;
 
+        int sum = lands[x][y];
         while(!q.isEmpty()) {
             Location l = q.poll();
 
@@ -107,14 +97,15 @@ public class Main {
 
                     if (L <= diff && diff <= R) {
                         visited[nx][ny] = true;
+                        sum += lands[nx][ny];
                         q.add(new Location(nx, ny));
-                        unions.get(unions.size() - 1).add(new Location(nx, ny));
+                        union.add(new Location(nx, ny));
                     }
                 }
             }
         }
 
-
+        return sum;
     }
 
     public static boolean check(int x, int y) {

--- a/박민수/16234_인구이동.java
+++ b/박민수/16234_인구이동.java
@@ -1,0 +1,134 @@
+package SoraeCodingMasters.B.BOJ16234;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 16234번
+ * 인구 이동
+ * 2024-02-28
+ * 시간 제한 : 2초
+ * 메모리 제한 : 512MB
+ */
+
+public class Main {
+    static final int[][] dir = {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+    static int N; // 1 <= N <= 50
+    static int L, R; // 1 <= L <= R <= 100
+    static int[][] lands;
+    static boolean[][] visited;
+    static int day = 0;
+    static List<List<Location>> unions;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+
+        lands = new int[N][N];
+        visited = new boolean[N][N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                lands[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        while (true) {
+            // 매 회차당 초기화
+            boolean stop = true;
+            visited = new boolean[N][N];
+            unions = new ArrayList<>();
+
+            // 연합 만들기
+            for (int x = 0; x < N; x++) {
+                for (int y = 0; y < N; y++) {
+                    if (!visited[x][y]) {
+                        bfs(x, y);
+                    }
+                }
+            }
+
+            for (List<Location> union : unions) {
+                if (union.size() > 1) {
+                    stop = false;
+
+                    // 연합 인구 계산
+                    int total = 0;
+                    for (Location l : union) {
+                        total += lands[l.x][l.y];
+                    }
+                    int people = total / union.size();
+
+                    // 연합 인구 이동
+                    for (Location l : union) {
+                        lands[l.x][l.y] = people;
+                    }
+                }
+            }
+
+            // 연합이 없다면 종료
+            if(stop) break;
+
+            day++;
+        }
+
+        System.out.println(day);
+    }
+    public static void bfs(int x, int y) {
+        unions.add(new ArrayList<>());
+        unions.get(unions.size() - 1).add(new Location(x, y));
+
+        Queue<Location> q = new LinkedList<>();
+        q.add(new Location(x, y));
+        visited[x][y] = true;
+
+        while(!q.isEmpty()) {
+            Location l = q.poll();
+
+            for (int i = 0; i < dir.length; i++) {
+                int nx = l.x + dir[i][0];
+                int ny = l.y + dir[i][1];
+
+                if (check(nx, ny) && !visited[nx][ny]) {
+                    int diff = Math.abs(lands[l.x][l.y] - lands[nx][ny]);
+
+                    if (L <= diff && diff <= R) {
+                        visited[nx][ny] = true;
+                        q.add(new Location(nx, ny));
+                        unions.get(unions.size() - 1).add(new Location(nx, ny));
+                    }
+                }
+            }
+        }
+
+
+    }
+
+    public static boolean check(int x, int y) {
+        return 0 <= x && x < N && 0 <= y && y < N;
+    }
+
+    public static class Location {
+        int x;
+        int y;
+
+        public Location(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+    }
+}


### PR DESCRIPTION
# BOJ 16234 인구 이동

## 사고 흐름

가장 먼저 BFS로 탐색을 진행하여 두 땅의 인구수 차이가 범위 안에 들어온다면, 연합(Set 자료구조)에 추가하는 방식으로 접근하였으나, 단순 Set 자료구조를 사용하면 연합이 서로 떨어져 있는 경우에도 같은 연합으로 판단하게 된다.

따라서, 떨어져 있는 연합을 각각 계산해줘야 하기 때문에 BFS를 한 번 돌 때마다 연합을 생성해주고 탐색 가능한 (두 땅의 인구수 차이가 범위 안에 들어오는 경우) 땅을 해당 연합에 추가해주는 방식으로 방향을 바꿨다.

내가 처음 푼 풀이는 BFS를 전체 다 돌고난 뒤에 한 번에 인구 이동을 해주었는데, 다른 풀이를 보니 하나의 BFS를 돌 때 바로바로 인구 이동을 해줌으로써 메모리와 시간을 줄였다.

<img width="770" alt="image" src="https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/75938496/ce473508-65d3-40d5-a27e-82458b02bb86">

시간이 줄긴 줄었다.

## 복기

Set 자료구조는 Java의 동일성에 의해 서로 다른 인스턴스라면 그 인스턴스가 갖는 값이 같더라도 다르다고 판단한다.

따라서, 동일 값 중복 제거를 위해 객체를 Set에 저장해야할 때는 해당 클래스에 `equals()`, `hashCode()`를 오버라이딩 해주어야 한다.
