### PR TITLE
2493 탑

### DIFF
--- a/박민수/2493_탑.java
+++ b/박민수/2493_탑.java
@@ -1,0 +1,56 @@
+package SoraeCodingMasters.A.BOJ2493;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 2493번
+ * 탑
+ * 2024-02-29
+ * 시간 제한 : 1.5초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int N; // 1 <= N <= 500,000
+    static Deque<Top> s = new ArrayDeque<>();
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < N; i++) {
+            int input = Integer.parseInt(st.nextToken());
+
+            while(!s.isEmpty() && s.peekLast().value <= input) {
+                s.pollLast();
+            }
+
+            if (s.isEmpty()) sb.append(0).append(" ");
+            else sb.append(s.peekLast().index).append(" ");
+
+            s.addLast(new Top(input, i + 1));
+
+        }
+
+        System.out.println(sb);
+    }
+
+    public static class Top {
+        int value;
+        int index;
+
+        public Top(int value, int index) {
+            this.value = value;
+            this.index = index;
+        }
+    }
+}


### PR DESCRIPTION
# BOJ 2493 탑

## 사고 흐름

입력의 크기가 최대 500,000이기 때문에 시간 초과를 조심해야겠다고 생각했다.

이 문제의 핵심은 자신보다 왼쪽에 있고, 가장 가까우면서, 자기보다 큰 값의 위치를 찾는것이다.

따라서, 시간 초과도 고려하여 O(N)의 시간 복잡도를 갖는 단조 스택을 활용하면 문제를 해결할 수 있다고 생각하였다.

스택에 내림차순으로 유지하는 과정을 통해 자신보다 왼쪽에 있고, 가장 가까우면서, 자기보다 큰 값의 위치를 찾을 수 있다.

- 스택이 비어있다면 자신보다 큰 값이 없기 때문에 0을 출력
- 자신보다 작은 값을 스택에서 제거하고 남은 값이 자신보다 왼쪽에 있으면서 큰 값이므로 해당 값의 위치를 출력하면 된다.

## 복기

단조 스택을 만들어가는 과정에서 얻는 정보를 이용하여 시간 복잡도를 줄일 수가 있다.