### PR TITLE
2467 용액

### DIFF
--- a/박민수/2467_용액.java
+++ b/박민수/2467_용액.java
@@ -28,31 +28,26 @@ public class Main {
             solutions[i] = Integer.parseInt(st.nextToken());
         }
 
-        int l = 0;
-        int r = N - 1;
         int mix = Integer.MAX_VALUE;
-        while(l < r) {
-            int sum = solutions[l] + solutions[r];
-            int abs = Math.abs(sum);
+        for (int i = 0; i < N - 1; i++) {
+            int l = i + 1;
+            int r = N - 1;
+            while(l <= r) {
+                int mid = (l + r) / 2;
+                int sum = solutions[i] + solutions[mid];
+                int abs = Math.abs(sum);
 
-            if (sum > 0) {
-                if (mix >= abs) {
+                if (mix > abs) {
+                    a = solutions[i];
+                    b = solutions[mid];
                     mix = abs;
-                    a = solutions[l];
-                    b = solutions[r];
                 }
-                r--;
-            } else if (sum == 0) {
-                a = solutions[l];
-                b = solutions[r];
-                break;
-            } else {
-                if (mix >= abs) {
-                    mix = abs;
-                    a = solutions[l];
-                    b = solutions[r];
-                }
-                l++;
+
+                if (sum > 0) {
+                    r = mid - 1;
+                } else if (sum < 0) {
+                    l = mid + 1;
+                } else break;
             }
         }
 

--- a/박민수/2467_용액.java
+++ b/박민수/2467_용액.java
@@ -1,0 +1,62 @@
+package SoraeCodingMasters.A.BOJ2467;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 2467번
+ * 용액
+ * 2024-03-03
+ * 시간 제한 : 1초
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int N; // 2 <= N <= 100,000
+    static int[] solutions;
+    static int a, b;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        N = Integer.parseInt(br.readLine());
+        solutions = new int[N];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            solutions[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int l = 0;
+        int r = N - 1;
+        int mix = Integer.MAX_VALUE;
+        while(l < r) {
+            int sum = solutions[l] + solutions[r];
+            int abs = Math.abs(sum);
+
+            if (sum > 0) {
+                if (mix >= abs) {
+                    mix = abs;
+                    a = solutions[l];
+                    b = solutions[r];
+                }
+                r--;
+            } else if (sum == 0) {
+                a = solutions[l];
+                b = solutions[r];
+                break;
+            } else {
+                if (mix >= abs) {
+                    mix = abs;
+                    a = solutions[l];
+                    b = solutions[r];
+                }
+                l++;
+            }
+        }
+
+        System.out.println(a + " " + b);
+    }
+
+}


### PR DESCRIPTION
# BOJ 2467 용액

## 사고 흐름

입력의 크기가 최대 100,000이기 때문에 시간 복잡도를 O(N) or O(NlogN)으로 
잡아야겠다고 생각했다.

두 용액을 합쳤을 때, 0에 가장 가까워야 하기 때문에 용액의 합을 절대값으로 비교해주어야 겠다고 생각했다.

입력이 오름차순으로 주어진다는 점에서 이분 탐색을 생각해보았지만, 방법이 떠오르지가 않았다.

투포인터를 사용하여 배열의 양쪽 끝에 포인터를 두고 시작해서 포인터가 가리키는 
1. 용액의 합이 양수라면 오른쪽 포인터를 왼쪽으로 옮기고 

2. 용액의 합이 음수라면 왼쪽 포인터를 오른쪽으로 옮기면서

두 용액의 합이 가장 0에 가까운 용액들을 찾았다.

## 복기

투포인트 경우에는 시간 복잡도가 O(N) 으로 풀 수 있고, 이분 탐색의 경우 O(NlogN)으로 풀 수 있으므로 이 문제에서는 투포인트가 더 효율적인 알고리즘이다.