### PR TITLE
2467 용액

### DIFF
--- a/김남주/2467_용액.cpp
+++ b/김남주/2467_용액.cpp
@@ -21,7 +21,8 @@ int main() {
 			a1 = a[l], a2 = a[r];
 		}
 		if (x < 0) l++;
-		else r--;
+		else if (x>0) r--;
+		else break;
 	}
 	cout << a1 << ' ' << a2;
 }

--- a/김남주/2467_용액.cpp
+++ b/김남주/2467_용액.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+int n, a[100000];
+inline int abs(int x) { return x < 0 ? -x : x; }
+int main() {
+	fastio;
+	//read_input;
+	cin >> n;
+	for (int i = 0;i < n;i++) cin >> a[i];
+	int ans = 2e9 + 1;
+	int l = 0, r = n - 1;
+	int a1, a2;
+	while (l < r) {
+		int x = a[l] + a[r];
+		if (ans > abs(x)) {
+			ans = abs(x);
+			a1 = a[l], a2 = a[r];
+		}
+		if (x < 0) l++;
+		else r--;
+	}
+	cout << a1 << ' ' << a2;
+}


### PR DESCRIPTION
## 사고 흐름
사실 이 문제는 예전에 이분 탐색으로 풀었던 문제임 (오름차순이라는 조건을 보고 떠올림)
그때 투 포인터로 O(N)으로 풀 수 있다는 것을 알게됐음

input이 100,000이므로 가장 쉽게 생각할 수 있는 방법인 O(N^2)로는 안됨

왼쪽 포인터와 오른쪽 포인터를 각각 배열의 왼쪽 끝과 오른쪽 끝으로 잡아서 현재 용액이 0보다 크면 오른쪽 포인터를 하나 감소하고 0보다 작으면 왼쪽 포인터를 하나 증가시켜서 풀 수 있음

위의 방법의 핵심 전제는 오름차순으로 정렬되어 있다는 것. 그래야 오른쪽 포인터를 하나 줄였을 때 용액의 혼합 결과가 감소하고, 왼쪽 포인터를 증가시켰을 때 용액의 혼합 결과가 증가함.

## 복기
투포인터 풀이에서 가장 빨랐던 풀이가 (입출력 트릭 제외) 12ms였는데 나는 16ms 나왔었음
차이는 0이 됐을때 투 포인터의 반복문을 break했던 것이었다. 그 부분을 수정해줬더니 12ms가 나왔음


이분 탐색으로는 다음과 같은 아이디어로 풀 수 있음

용액의 값을 처음부터 끝까지 순회하면서 현재 용액에 -1을 곱한 값의 이상이 되는 첫번째 값을 현재 용액 이후의 값들 중에서 찾는다.
그런데 그 값보다 작은 값(-1을 곱한 값의 미만이 되는 첫번째 값)이 답이 될 수 있으므로 위에서 찾은 값의 이전 인덱스도 같이 비교한다.
