### PR TITLE
7682 틱택토

### DIFF
--- a/김남주/7682_틱택토.cpp
+++ b/김남주/7682_틱택토.cpp
@@ -1,24 +1,27 @@
 #include <iostream>
 #include <cstring>
+#include <cmath>
 
 #define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
 #define read_input freopen("input.txt","r",stdin)
 using namespace std;
 
-string s;
-
+string s=".........";
+bool possible[20000];
+char l[2] ={'X','O'};
 bool check(char cur) {
     bool f=false;
     for (int r=0;r<3;r++) {
         f=true;
         for (int c=0;c<3;c++) {
-            if (s[3*r+c]!=cur) {
+            if (s[r*3+c]!=cur) {
                 f=false;
                 break;
             }
         }
         if (f) return true;
     }
+
     for (int c=0;c<3;c++) {
         f=true;
         for (int r=0;r<3;r++) {
@@ -29,43 +32,53 @@ bool check(char cur) {
         }
         if (f) return true;
     }
-    if (s[0]==cur && s[4]==cur && s[8]==cur) return true;
-    if (s[2]==cur && s[4]==cur && s[6]==cur) return true;
+    if (s[0]==cur&&s[4]==cur&&s[8]==cur) return true;
+    if (s[2]==cur&&s[4]==cur&&s[6]==cur) return true;
     return false;
 }
-
-pair<bool,bool> x_o_f() {
-    bool x_f=check('X');
-    bool o_f=check('O');
-    return {x_f,o_f};
+void bf(int num, int b, int c) {
+    if (num==9) {
+        possible[b]=true;
+        return;
+    }
+    if (check('X')) {
+        possible[b]=true;
+        return;
+    }
+    if (check('O')) {
+        possible[b]=true;
+        return;
+    }
+    int x=1;
+    for (int i=0;i<9;i++) {
+        if (s[i]=='.') {
+            s[i]=l[c];
+            bf(num+1,b+x*(c?1:2),c?0:1);
+            s[i]='.';
+        }
+        x*=3;
+    }
 }
+
 int main() {
     fastio;
     // read_input;
+    bf(0,0,0);
+    string input;
     while(1) {
-        cin>>s;
-        if (s=="end")break;
-        int x_n=0,o_n=0;
-        for (int i=0;i<9;i++)
-            if (s[i]=='O') o_n++;
-            else if (s[i]=='X') x_n++;
-        if (!(x_n-o_n==1 || x_n==o_n)) {
-            cout<<"invalid"<<'\n';
-            continue;
+        cin>>input;
+        if (input.front()=='e') break;
+        int idx=0;
+        int x=1;
+        for (int i=0;i<9;i++) {
+            if (input[i]=='X') {
+                idx+=x*2;
+            } else if (input[i]=='O') {
+                idx+=x;
+            }
+            x*=3;
         }
-        auto [x_f,o_f]=x_o_f();
-        if (x_f && x_n-o_n!=1) {
-            cout<<"invalid"<<'\n';
-            continue;
-        }
-        if (o_f && x_n!=o_n) {
-            cout<<"invalid"<<'\n';
-            continue;
-        }
-        if (!x_f&&!o_f&&x_n+o_n!=9) {
-            cout<<"invalid"<<'\n';
-            continue;
-        }
-        cout<<"valid"<<'\n';
+        if (possible[idx]) cout<<"valid\n";
+        else cout<<"invalid\n";
     }
 }

--- a/김남주/7682_틱택토.cpp
+++ b/김남주/7682_틱택토.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+string s;
+
+bool check(char cur) {
+    bool f=false;
+    for (int r=0;r<3;r++) {
+        f=true;
+        for (int c=0;c<3;c++) {
+            if (s[3*r+c]!=cur) {
+                f=false;
+                break;
+            }
+        }
+        if (f) return true;
+    }
+    for (int c=0;c<3;c++) {
+        f=true;
+        for (int r=0;r<3;r++) {
+            if (s[r*3+c]!=cur) {
+                f=false;
+                break;
+            }
+        }
+        if (f) return true;
+    }
+    if (s[0]==cur && s[4]==cur && s[8]==cur) return true;
+    if (s[2]==cur && s[4]==cur && s[6]==cur) return true;
+    return false;
+}
+
+pair<bool,bool> x_o_f() {
+    bool x_f=check('X');
+    bool o_f=check('O');
+    return {x_f,o_f};
+}
+int main() {
+    fastio;
+    // read_input;
+    while(1) {
+        cin>>s;
+        if (s=="end")break;
+        int x_n=0,o_n=0;
+        for (int i=0;i<9;i++)
+            if (s[i]=='O') o_n++;
+            else if (s[i]=='X') x_n++;
+        if (!(x_n-o_n==1 || x_n==o_n)) {
+            cout<<"invalid"<<'\n';
+            continue;
+        }
+        auto [x_f,o_f]=x_o_f();
+        if (x_f && x_n-o_n!=1) {
+            cout<<"invalid"<<'\n';
+            continue;
+        }
+        if (o_f && x_n!=o_n) {
+            cout<<"invalid"<<'\n';
+            continue;
+        }
+        if (!x_f&&!o_f&&x_n+o_n!=9) {
+            cout<<"invalid"<<'\n';
+            continue;
+        }
+        cout<<"valid"<<'\n';
+    }
+}


### PR DESCRIPTION
## 사고 흐름
나올 수 있는 판의 수는 최대 경우의 수가 3^10이지만 두는 순서도 경우를 다르게 하는 요인 중 하나이므로 재귀를 이용한 브루트포스로 답을 구한다면 3^10 보다 더 많은 케이스를 검사해야 할 수도 있음

여러 테스트 케이스를 통해 어떤 경우에 invalid 한지 파악하고, invalid하지 않다면 valid로 출력

valid한 경우
1. O의 개수가 X의 개수와 같거나 1 더 커야함
2. 만약 X가 빙고가 나왔다면 X의 개수가 O의 개수보다 1 커야함
3. 만약 O가 빙고가 나왔다면 X의 개수와 O의 개수가 같아야 함
4. 만약 둘다 빙고가 나오지 않았다면 게임판이 가득 차야함

위의 조건부터 Not 연산자를 붙여서 해당 조건의 not에 해당한다면 "invalid"를 출력하고 continue.

## 복기
연습을 위해 재귀를 통한 브루트 포스로도 풀어봤다.

판의 상태를 3진수로 나타내어 해당 3진수의 값을 인덱스로 나타낸다.
ex) OOXXOOXOO=3^0 + 3^1 + 2*3^2 + 2*3^3  + ...

해당 인덱스의 값을 true로 체크하고 탈출 (`return`)하는 base case는 다음과 같다.
1. 판이 다 찬 경우
2. 빙고가 발생한 경우

이렇게 탈출하게 되면 뒤의 경우는 더 진행하지 않는다. 배열은 `false`를 기본값으로 자동으로 초기화 되므로 진행되지 않은 경우는 invalid이다.

두번째 커밋에 반영