### PR TITLE
2668 숫자고르기 

### DIFF
--- a/박민수/2668_숫자고르기.java
+++ b/박민수/2668_숫자고르기.java
@@ -3,12 +3,6 @@ package SoraeCodingMasters.A.BOJ2668;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 /***
  * 백준 2668번
@@ -22,9 +16,10 @@ public class Main {
     static int N; // 1 <= N <= 100
     static int[] numbers;
     static boolean[] visited;
-    static Set<Integer> index;
-    static Set<Integer> value;
-    static Set<Integer> ans = new HashSet<>();
+
+    static StringBuilder sb = new StringBuilder();
+    static int ans = 0;
+
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         N = Integer.parseInt(br.readLine());
@@ -36,36 +31,21 @@ public class Main {
 
         for (int i = 1; i <= N; i++) {
             visited = new boolean[N + 1];
-            index = new HashSet<>();
-            value = new HashSet<>();
-
-            dfs(i);
-
-            if (index.size() == value.size()) {
-                ans.addAll(index);
-            }
+            dfs(i, i);
         }
-
-        List<Integer> sortAns = new ArrayList<>(ans);
-        Collections.sort(sortAns);
-
-        StringBuilder sb = new StringBuilder();
-        sb.append(sortAns.size()).append("\n");
-        for (int n : sortAns) {
-            sb.append(n).append("\n");
-        }
+        System.out.println(ans);
         System.out.println(sb);
     }
 
-    public static void dfs(int start) {
-        visited[start] = true;
-        index.add(start);
+    public static void dfs(int start, int index) {
+        visited[index] = true;
+        int next = numbers[index];
 
-        int next = numbers[start];
-        value.add(next);
-
-        if (!visited[next]) {
-            dfs(next);
-        }
+        if (visited[next]) {
+            if (start == next) {
+                sb.append(start).append("\n");
+                ans++;
+            }
+        } else dfs(start, next);
     }
 }


### PR DESCRIPTION
# BOJ 2668 숫자고르기

## 사고 흐름

입력의 크기가 최대 100이기 때문에 완전 탐색을 가장 먼저 생각해보았으나, 모든 집합에 대해 탐색하는 O(2^N - 1) 만큼의 시간 복잡도가 필요해서 불가능하였다.

따라서, Set 자료구조를 인덱스 저장용 인덱스에 해당하는 값 저장용 두 개로 나누어 DFS를 수행하고 두 Set의 사이즈가 같을 때 최종 집합에 추가하는 방식으로 해결하였다.

## 복기

이 문제의 핵심은 **사이클을 찾는 문제**였다.

즉, DFS로 탐색하다가 처음 시작한 값을 다시 마주치면 사이클로 판별하고 집합에 추가하면 된다.

입력이 작아서 그런지 시간은 별 차이가 없었다.

<img width="773" alt="image" src="https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/75938496/3b16d9c3-d47b-4425-817e-a74610242c52">

사이클을 탐색하는 방법에 대해서 알아둬야할 것 같다.


