### PR TITLE
2668 숫자고르기 & 1863 스카이라인 쉬운거

### DIFF
--- a/김남주/1863_스카이라인쉬운거.cpp
+++ b/김남주/1863_스카이라인쉬운거.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <vector>
+#include <stack>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+int n;
+int main() {
+    fastio;
+    // read_input;
+    cin>>n;
+    stack<int> stk;
+    int x,y;
+    int ans=0;
+    for (int i=0;i<n;i++) {
+        cin>>x>>y;
+        while (!stk.empty() && stk.top()>y) {
+            stk.pop();
+            ans++;
+        }
+        if (stk.empty() || stk.top()<y) stk.push(y);
+    }
+    while (!stk.empty() && stk.top()) {
+        stk.pop();
+        ans++;
+    }
+    cout<<ans;
+}


### PR DESCRIPTION
**내일 분량 까지 한번에 풀었습니다. 스카이라인 문제는 스포될 수 있으니 토글로 만듬**

# 숫자고르기

## 사고 흐름
두 집합이 일치하면서 '최대'로 숫자를 고르는 경우를 찾아라.
완전 탐색으로 모든 경우를 찾을 필요 없이 그리디 처럼 특정 알고리즘을 통해 찾을 수 있을 것이라 생각했음

그렇다면 특정 알고리즘은? -> 여러 입력 예시로 찾아야 한다. 나는 다음과 같은 사고 흐름으로 규칙을 찾았다.

고를 수 있는 가장 쉬운 경우부터 생각해보자.
3
3
위처럼 숫자가 일치하는 경우이다. 이때는 무조건 선택할 수 있다.

두번째로는
1 3
3 1
처럼 엇갈리는 경우이다. 순차적으로 탐색하면서는 1을 골라야할지 결정할 수 없으나 3까지 갔을때는 이전의 1을 고를 수 있다는 것을 알 수 있다.
-> 3 밑의 수가 1 이므로, 위의 수가 1인 수를 고르면 아래에 3이 있으므로 집합이 일치

세번째로는
1 3 5  
3 5 1
처럼 여러개가 엇갈리는 경우. 1,3을 순회할때는 이 숫자를 골라야 되는지 알 수 없지만 비로소 5를 가야 1,3을 고를 수 있다는 것을 알 수 있음
-> 5밑의 수가 1임 -> 1 밑의 수가 3임 -> 3밑의 수가 5임 -> 5 밑의 수가 1임

위의 규칙을 찾아냈고 이는 그래프의 사이클을 찾아내는 것과 같은 원리임을 알았다.
위의 수를 노드, 아래 수를 간선처럼 생각해서 사이클을 찾아내는 DFS 함수를 작성하고 모든 사이클 안에 있는 모든 노드가 선택할 수 있는 숫자이다.

## 복기
사이클을 찾는 코드에서 중복된 연산을 최대한 피하려고 bool 배열을 두개 뒀다.
1. 이미 사이클 안에 포함된 노드 체크
2. 현재만의 DFS의 방문 처리를 수행한 배열

- DFS 도중에 1번에 속한 노드를 만나면 바로 return
- DFS 도중 1번 노드를 만나지 않았는데 2번 노드를 만났다면 사이클이 발생한 것이므로 1번 노드에 체크

다른 사람들의 풀이를 보면 코드의 길이가 400B 가 거의 넘지 않았는데
나처럼 중복된 연산을 줄이진 않았지만 어차피 입력의 크기가 최대 100이므로 시간 자체는 크게 차이 나지 않음 (모두 0ms)
따라서 코딩테스트와 같은 시험 상황에서는 입력이 작은 경우 효율보다 작성하기 쉬운 코드를 작성하는 것이 좋을 듯

---

<details>
<summary><h1>스카이라인 쉬운거 (스포주의)</h1></summary>

## 사고 흐름
바로 든 첫 인상은 그래프로 표현하고 BFS로 마킹해야 하나 생각했지만 x,y가 최대 100만과 50만이므로 그래프로 표현할 순 없을 것 같다고 생각.

높이(y)가 바뀔 때마다 건물의 수가 카운트 될 가능성이 있었고 이 부분의 규칙을 유심히 살펴봄
높이가 낮아지면 무조건 카운트, 그러나 최소 건물의 수를 구하는 것이므로 현재 입력값(y)보다 높은 건물들에 대해 모두 count해준다.

-> 이는 Monotonic stack을 만드는 과정을 통해 구할 수 있음

## 복기
저번에 알려준 Monotonic Stack 아이디어 잘 쓰고 있습니다.

</details>