### PR TITLE
1863 스카이라인 쉬운거 

### DIFF
--- a/박민수/1863_스카이라인쉬운거.java
+++ b/박민수/1863_스카이라인쉬운거.java
@@ -1,0 +1,53 @@
+package SoraeCodingMasters.A.BOJ1863;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 번
+ *
+ * 2024-03-
+ * 시간 제한 : 초
+ * 메모리 제한 : MB
+ */
+
+public class Main {
+    static int n; // 1 <= n <= 50,000
+    static int x, y; // 1 <= x <= 1,000,000 / 0 <= y <= 500,000
+    static int[] skyline;
+    static Deque<Integer> stack = new ArrayDeque<>();
+    static int ans = 0;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        n = Integer.parseInt(br.readLine());
+        skyline = new int[n + 2];
+
+        for (int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            x = Integer.parseInt(st.nextToken());
+            skyline[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for(int i = 0; i <= n + 1; i++) {
+            int y = skyline[i];
+            if (stack.isEmpty() || stack.peekLast() < y) {
+                stack.offerLast(y);
+            } else {
+                while (!stack.isEmpty() && stack.peekLast() >= y) {
+                    if (stack.peekLast() > y) ans++;
+                    stack.pollLast();
+                }
+                stack.offerLast(y);
+            }
+        }
+
+        System.out.println(ans);
+    }
+
+}


### PR DESCRIPTION
# BOJ 1863 스카이라인 쉬운거

## 사고 흐름

처음에는 예제만 보고 이전 값과 비교했을 때 감소하는 구간만을 체크하여 제출했는데 틀렸다.

이 방법은 계속 증가 하다가 한번에 감소하는 케이스에서 개수를 파악할 수 없으므로 **내가 현재 보고 있는 값 이전에 나보다 큰 값이 몇개였는지 파악**해야 했다.

따라서, 모노톤 스택을 활용하여

1. 증가하는 구간이면 스택에 현재 보고있는 값을 넣어준다.

2. 감소하는 구간이라면 현재 보고있는 값보다 크거나 같은 값을 다 스택에서 꺼낸다.

   이 때, 건물의 개수를 세야하는데 **현재 보고 있는 값 보다 큰 값 만 체크**해준다.

위의 과정을 0 - N + 1 구간에 적용해주면 되므로 시간 복잡도는 O(N)이 나온다.

## 복기

문제 이름에 쉬운거라고 붙어 있는데 쉽진 않았다.

난이도 기여를 보닌까 비슷한 문제로 [탑](https://boj.kr/2493)이 있었다.
