### PR TITLE
22251 빌런 호석

### DIFF
--- a/박민수/22251_빌런호석.java
+++ b/박민수/22251_빌런호석.java
@@ -1,0 +1,70 @@
+package SoraeCodingMasters.C.BOJ22251;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 22251번
+ * 빌런 호석
+ * 2024-03-08
+ * 시간 제한 : 1초
+ * 메모리 제한 : 512MB
+ */
+
+public class Main {
+    static int N, K, P, X;
+    static int ans = 0;
+    static int[] tf;
+    static int[] cf;
+    static int[] led = {123, 72, 61, 109, 78, 103, 119, 73, 127, 111};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        P = Integer.parseInt(st.nextToken());
+        X = Integer.parseInt(st.nextToken());
+
+        tf = createFloor(X);
+
+        for (int i = 1; i <= N; i++) {
+            int count = 0;
+            cf = createFloor(i);
+            for (int j = 0; j < K; j++) {
+                count += compareDigit(tf[j], cf[j]);
+            }
+
+            if (1 <= count && count <= P) ans++;
+        }
+
+        System.out.println(ans);
+    }
+
+    public static int[] createFloor(int n) {
+        int[] temp = new int[K];
+        for(int i = K - 1; i >= 0; i--) {
+            temp[i] = n % 10;
+            n /= 10;
+        }
+
+        return temp;
+    }
+
+    public static int compareDigit(int t, int c) {
+        int diff = 0;
+
+        int xor = led[t] ^ led[c];
+
+        while (xor > 0) {
+            if (xor % 2 == 1) diff++;
+
+            xor /= 2;
+        }
+
+        return diff;
+    }
+}


### PR DESCRIPTION
# BOJ 22251 빌런 호석

## 사고 흐름

처음에 `반전 이후에 디스플레이에 올바른 수가 보여지면서 1 이상 N 이하가 되도록 바꿔서` 라는 문장 때문에 문제를 이해하는게 좀 어려웠는데, 이 문제에서 요구하는 것은 다음과 같다.

현재 위치한 층인 X가 주어지면 디스플레이의 LED를 최소 1개 최대 P개를 반전시켜서 1과 N 사이의 값을 만들 수 있는 경우의 수를 체크하는 것이다.

나의 풀이는 다음과 같다.

각 숫자에 대한 LED 정보를 미리 하드코딩으로 선언해주고 1 - N 층 까지 층을 하나씩 늘려가면서 X와 XOR 연산을하여 켜져있는 bit의 개수가 1과 P 사이의 값이라면 체크를 해주어서 풀었다.

따라서, 시간 복잡도는 O(N)이 나온다.

## 복기

K값에 맞추어 자리수를 만들어야 하는 조건 때문에 StringBuilder를 사용하여 문자열을 만들어서 비교하였는데 아무래도 String을 만드는 비용이 크다보니 시간이 오래걸리게 된 것 같다.

int 배열을 만들어서 비교하닌까 시간이 줄긴 줄었다. String을 만드는 연산을 최대한 피하도록 해야겠다.
