### PR TITLE
4485 녹색 옷 입은 애가 젤다지? & 1253 좋다

### DIFF
--- a/김남주/1253_좋다.cpp
+++ b/김남주/1253_좋다.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <cstring>
+#include <algorithm>
+#include <list>
+#include <unordered_map>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+const int M=1e9;
+int n,A[2000];
+int main() {
+    fastio;
+    // read_input;
+    cin>>n;
+    unordered_map<int,list<int>> map;
+    for (int i=0;i<n;i++) {
+        cin>>A[i];
+        map[A[i]].push_back(i);
+    }
+    int ans=0;
+
+    for (int i=0;i<n-1;i++) {
+        for (int j=i+1;j<n;j++) {
+            int cur=A[i]+A[j];
+            if (map.find(cur)==map.end()) continue;
+            for (auto it=map[cur].begin();it!=map[cur].end();) {
+                if (*it==i || *it==j) ++it;
+                else {
+                    ans++;
+                    map[cur].erase(it++);
+                }
+                
+            }
+        }
+    }
+    cout<<ans;
+}

--- a/김남주/4485번_녹색옷입은애가젤다지.cpp
+++ b/김남주/4485번_녹색옷입은애가젤다지.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <cstring>
+#include <algorithm>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+using pii=pair<int,int>;
+constexpr int INF=1e9;
+int n;
+int g[125][125];
+int dy[4]{0,0,1,-1},dx[4]{1,-1,0,0};
+
+struct E {
+    int dst,c;
+    bool operator>(const E& o) const {return c>o.c;}
+};
+int dijkstra() {
+    vector<vector<int>> dist(n,vector<int>(n,INF));
+    dist[0][0]=g[0][0];
+    priority_queue<E,vector<E>,greater<E>> pq;
+    pq.push({0,g[0][0]});
+    while (!pq.empty()) {
+        int cy=pq.top().dst/n,cx=pq.top().dst%n;
+        int cc=pq.top().c;
+        pq.pop();
+        if (cy==n-1 && cx==n-1) break;
+        for (int d=0;d<4;d++) {
+            int ny=cy+dy[d],nx=cx+dx[d];
+            if (ny<0||ny>=n||nx<0||nx>=n) continue;
+            if (dist[ny][nx]<=cc+g[ny][nx]) continue;
+            dist[ny][nx]=cc+g[ny][nx];
+            pq.push({ny*n+nx,dist[ny][nx]});
+        }
+    }
+    return dist[n-1][n-1];
+}
+
+int main() {
+    fastio;
+    // read_input;
+    cin>>n;
+    int i=1;
+    while(n) {
+        for (int i=0;i<n;i++) for (int j=0;j<n;j++) cin>>g[i][j];
+        cout<<"Problem "<<i<<": "<<dijkstra()<<'\n';
+        cin>>n;
+        ++i;
+    }
+}


### PR DESCRIPTION
# 녹색 옷 입은 애가 젤다지?
## 사고 흐름
너무 전형적인 다익스트라 
## 복기
빠르게 풀 수 있도록 하자

---

# 좋다

## 사고 흐름
문제에서 요구하는 것은 서로 다른 두 수의 합으로 나타낼 수 있는 수의 개수.
-> 즉, 나를 제외한 다른 두 수로 나를 만들 수 있는가
ex) 0 0 1
위 에서는 좋은 수가 하나도 없다.

그렇다면 모든 수의 합을 따저봐야 되고 -> O(N^2): N≤2000 이므로 문제 없음
i : 0~n-1, j: 0~n-1 순회하면서 i,j가 아닌 수의 개수를 찾는것
따라서 unordered_map을 사용했음 (자바에선 아마 HashMap?)
map[값] -> 인덱스를 담은 연결리스트
따라서 map[값]에 있는 연결리스트를 순회하면서 i, j 인덱스에 해당하지 않으면 카운트 해주고, 해당 원소를 제거 해줬음 (제거를 O(1)으로 하기 위해 연결리스트를 선정)

## 복기
정렬 후 이분탐색으로 찾는 풀이도 생각했었다.
여기서 핵심은 이미 '좋은 수'로 카운트 한것은 다시 카운트하면 안되므로 삭제를 해주거나 표시를 해줘야 된다는 것
그러나 삭제 하기에는 O(n)이 걸리고, 표시를 해줘야 되는데 단순 표시로는 선형적으로 건너 뛰므로 시간복잡도가 증가
따라서 마치 연결리스트 처럼 다음 원소를 가르키는 배열을 하나 선언해주고 여기에 더해주면서 마치 삭제한 효과를 주면 된다
시간 복잡도는 O(N^2 lgN)

그리고 사람들이 가장 많이 풀었던 것은 투 포인터 풀이
투 포인터 풀이도 정렬이 됐다는 것을 가정한 풀이
핵심은 정렬 후 i : 0 ~ n-1 까지 순회하면서 현재 수를 서로 다른 두 수의 합으로 만들 수 있는 조합이 있는가를 투 포인터로 찾아주는 것 ->O(N^2)
