### PR TITLE
1806 부분합

### DIFF
--- a/박민수/1806_부분합.java
+++ b/박민수/1806_부분합.java
@@ -9,15 +9,15 @@ import java.util.StringTokenizer;
 
 /***
  * 백준 1806번
- * 부분합
+ * 부분합 (Two Pointer)
  * 2024-03-14
  * 시간 제한 : 0.5초 (java 11 -> 1초)
  * 메모리 제한 : 128MB
  */
 
-public class Main {
+public class TP {
     static int N, S; // 10 <= N <= 100,000 / 0 <= S <= 100,000,000
-    static Deque<Integer> dq;
+    static int[] arr;
     static int cur = 0;
     static int minLen = Integer.MAX_VALUE;
 
@@ -30,25 +30,29 @@ public class Main {
 
         N = Integer.parseInt(st.nextToken());
         S = Integer.parseInt(st.nextToken());
+        arr = new int[N];
 
-        dq = new ArrayDeque<>();
         st = new StringTokenizer(br.readLine());
         for(int i = 0; i < N; i++) {
-            int item = Integer.parseInt(st.nextToken());
-            if (cur + item < S) {
-                cur += item;
-                dq.offerLast(item);
-            } else {
-                cur += item;
-                dq.offerLast(item);
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
 
-                while(!dq.isEmpty() && cur - dq.peekFirst() >= S) {
-                    cur -= dq.pollFirst();
+        int l = 0;
+        int r = 0;
+
+        while(l <= r && r < N) {
+            cur += arr[r++];
+
+            if (cur >= S) {
+                while(cur - arr[l] >= S) {
+                    cur -= arr[l++];
                 }
 
-                minLen = Math.min(minLen, dq.size());
+                minLen = Math.min(minLen, r - l);
             }
+
         }
+
 
         StringBuilder sb = new StringBuilder();
         if (minLen == Integer.MAX_VALUE) sb.append(0);

--- a/박민수/1806_부분합.java
+++ b/박민수/1806_부분합.java
@@ -1,0 +1,59 @@
+package SoraeCodingMasters.A.BOJ1806;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+/***
+ * 백준 1806번
+ * 부분합
+ * 2024-03-14
+ * 시간 제한 : 0.5초 (java 11 -> 1초)
+ * 메모리 제한 : 128MB
+ */
+
+public class Main {
+    static int N, S; // 10 <= N <= 100,000 / 0 <= S <= 100,000,000
+    static Deque<Integer> dq;
+    static int cur = 0;
+    static int minLen = Integer.MAX_VALUE;
+
+    // 5 5
+    // 1 4 5 3 2
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        S = Integer.parseInt(st.nextToken());
+
+        dq = new ArrayDeque<>();
+        st = new StringTokenizer(br.readLine());
+        for(int i = 0; i < N; i++) {
+            int item = Integer.parseInt(st.nextToken());
+            if (cur + item < S) {
+                cur += item;
+                dq.offerLast(item);
+            } else {
+                cur += item;
+                dq.offerLast(item);
+
+                while(!dq.isEmpty() && cur - dq.peekFirst() >= S) {
+                    cur -= dq.pollFirst();
+                }
+
+                minLen = Math.min(minLen, dq.size());
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        if (minLen == Integer.MAX_VALUE) sb.append(0);
+        else sb.append(minLen);
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# BOJ 1806 부분합

## 사고 흐름

문제를 읽고 **연속적인 수들의 부분합**을 구해야하므로 가장 먼저 누적합을 떠올렸다. 1 - N 까지 모든 길이의 부분합을 구하는 것은 시간 복잡도가 O(N^2) 이라 N의 범위가 최대 100,000인 이 문제에서는 시간초과가 발생하게 된다.

따라서, 처음 풀이는 다음과 같이하여 시간 복잡도를 O(2 * N) 정도로 해결하였다.
1. 덱(Deque)을 하나 선언한다.
2. 배열의 요소를 덱의 뒷단에 하나씩 넣는다.
   1. 덱 안에 있는 요소의 총합이 S가 넘게될 때, 덱의 앞단에서 요소를 하나씩 제거한다 (덱 요소의 총합 >= S 를 유지하면서)
   2. 위 과정을 지난 덱의 크기를 구하고자 하는 최솟값과 비교하여 갱신한다.


## 복기

문제의 유형을 보닌까 투 포인터가 있었는데, 다시보니 내가 풀었던 방식이 투포인터와 유사한 방식으로 풀었다는걸 알았다. (대신 성능은 안좋음)

시간이 줄긴 줄었는데, 다른 사람들은 144ms 까지 줄인걸 봤다. (입력의 차이인듯 하다.)

<img width="718" alt="스크린샷 2024-03-14 오후 1 02 08" src="https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/75938496/68b880fe-f3dc-4cec-8187-f7bd39196d3d">
