### PR TITLE
1987 알파벳

### DIFF
--- a/김남주/1987_알파벳.cpp
+++ b/김남주/1987_알파벳.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <vector>
+#include <stack>
+#include <cstring>
+#include <algorithm>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+#define FOR(i,n) for (int i=0;i<(n);i++)
+
+int dy[4]{ 1,-1,0,0 }, dx[4]{ 0,0,1,-1 };
+int dp[20][20];
+int r, c;
+char g[20][20];
+
+int ans = 0, cur = 0;
+void dfs(int y, int x, int b) {
+	if (dp[y][x] == b) return;
+	dp[y][x] = b;
+	ans = max(ans, ++cur);
+	b |= (1 << (g[y][x] - 'A'));
+	for (int d = 0;d < 4;d++) {
+		int ny = y + dy[d], nx = x + dx[d];
+		if (ny < 0 || ny >= r || nx < 0 || nx >= c || b & (1 << (g[ny][nx] - 'A'))) continue;
+		dfs(ny, nx, b);
+	}
+	--cur;
+}
+int main() {
+	fastio;
+	//read_input;
+	cin >> r >> c;
+	FOR(i, r) FOR(j, c) { cin >> g[i][j]; dp[i][j] = -1; }
+	dfs(0, 0, 0);
+	cout << ans;
+}


### PR DESCRIPTION
## 사고 흐름
가장 먼저 생각해 볼 수 있는 풀이는 DFS,BFS였으나 방문한 알파벳에 따라 각 경우가 달라지므로 하나의 visited배열을 공유할 수 없음

따라서 DFS를 이용한 백트래킹으로 풀기로 했음.

이동할 수 있는 경우는 상하좌우로 총 4가지, 알파벳은 26개 있으므로 최대 4^26의 경우의 수가 존재할 것 같지만,
보드 바깥으로 나갈 수 없고 같은 알파벳을 방문하지 않으므로 최대 2^26 내의 경우의 수가 있을 것 같기에 시간이 꽤 걸릴 것으로 예상되나 2초 안에는 들어옴

## 복기
단순 DFS를 이용한 백트래킹으로 풀게 되면 중복되는 경우의 수가 매우 많아짐
예시)
ACCCC
CBDEF
위와 같은 보드를 생각해보자. 처음에 오른쪽으로 출발하나 아래로 출발하나 뒤에는 분명 같은 경우의 수를 카운트 할 것이 자명한데 이를 중복해서 카운트하게 됨

따라서 이러한 중복된 연산을 피하기 위해 이를 같은 경우의 수로 인지할 수 있는 표시가 필요함
`DP[20][20]`: `[y, x] -> 현재까지 방문한 알파벳 비트 마스크`의 의미를 갖는 배열을 선언하면 A에서 오른쪽으로 출발해서 먼저 경우를 카운트했으면 `DP[1][1]-> ACB를 방문한 상태`로 체크가 되어 있으므로 그 다음 재귀에서 아래로 출발한 경우는 카운트하지 않게끔 return해주면 된다.

![image](https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/55823958/d726e6a3-19ce-44a6-b810-782eb94096db)
중복 체크 X
![image](https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/55823958/7853b484-2ad3-4115-b819-a0479fa68402)
중복 체크 O
