### PR TITLE
9935 문자열 폭발

### DIFF
--- a/김남주/9935_문자열폭발.cpp
+++ b/김남주/9935_문자열폭발.cpp
@@ -16,26 +16,20 @@ int main() {
     // read_input;
     cin>>str>>bomb;
     int n=strlen(str),m=strlen(bomb);
-    vector<int> stk;
-    bool flag=false;
-    for (int i=0;i<n;i++) {
-        if (str[i]==bomb[0]) stk.push_back(0);
-        else if(!stk.empty()) {
-            if (str[i]==bomb[stk.back()+1]) stk.push_back(stk.back()+1);
-            else {
+    int i=0,e=0;
+    for (;e<n;e++) {
+        str[i++]=str[e];
+        if (i-m<0) continue;
+        bool flag=false;
+        for (int j=0;j<m;j++) {
+            if (str[i-m+j]!=bomb[j]) {
                 flag=true;
-                for (int i=0;i<(int)stk.size();i++) cout<<bomb[stk[i]];
-                stk.clear();
-                cout<<str[i];
+                break;
             }
-        } else cout<<str[i],flag=true;
-        if (!stk.empty() && stk.back()==m-1) {
-            for (int _=0;_<m;_++) stk.pop_back();
         }
+        if (flag) continue;
+        i=i-m;
     }
-    if (!stk.empty()) {
-        for(auto&i:stk)cout<<bomb[i];
-        flag=true;
-    }    
-    if(!flag)cout<<"FRULA";
+    for (int j=0;j<i;j++) cout<<str[j];
+    if(!i) cout<<"FRULA";
 }

--- a/김남주/9935_문자열폭발.cpp
+++ b/김남주/9935_문자열폭발.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <vector>
+#include <deque>
+#include <cstring>
+#include <numeric>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(false)
+#define read_input freopen("input.txt","r",stdin)
+using namespace std;
+
+#define MAX 1'000'000
+char str[MAX+1],bomb[37];
+
+int main() {
+    fastio;
+    // read_input;
+    cin>>str>>bomb;
+    int n=strlen(str),m=strlen(bomb);
+    vector<int> stk;
+    bool flag=false;
+    for (int i=0;i<n;i++) {
+        if (str[i]==bomb[0]) stk.push_back(0);
+        else if(!stk.empty()) {
+            if (str[i]==bomb[stk.back()+1]) stk.push_back(stk.back()+1);
+            else {
+                flag=true;
+                for (int i=0;i<(int)stk.size();i++) cout<<bomb[stk[i]];
+                stk.clear();
+                cout<<str[i];
+            }
+        } else cout<<str[i],flag=true;
+        if (!stk.empty() && stk.back()==m-1) {
+            for (int _=0;_<m;_++) stk.pop_back();
+        }
+    }
+    if (!stk.empty()) {
+        for(auto&i:stk)cout<<bomb[i];
+        flag=true;
+    }    
+    if(!flag)cout<<"FRULA";
+}

--- a/김남주/9935_문자열폭발.cpp
+++ b/김남주/9935_문자열폭발.cpp
@@ -9,13 +9,13 @@
 using namespace std;
 
 #define MAX 1'000'000
-char str[MAX+1],bomb[37];
+string str,bomb;
 
 int main() {
     fastio;
     // read_input;
     cin>>str>>bomb;
-    int n=strlen(str),m=strlen(bomb);
+    int n=str.size(),m=bomb.size();
     int i=0,e=0;
     for (;e<n;e++) {
         str[i++]=str[e];
@@ -30,6 +30,7 @@ int main() {
         if (flag) continue;
         i=i-m;
     }
-    for (int j=0;j<i;j++) cout<<str[j];
+    str.resize(i);
+    cout<<str;
     if(!i) cout<<"FRULA";
 }


### PR DESCRIPTION
## 사고 흐름
입력의 크기가 100만이므로 O(N^2)의 방식으로는 불가능

-> 폭탄에는 중복되는 문자가 없음
폭발 문자열을 찾고 없앤 뒤 이어서 나오는 구조가 재귀를 통해 해결할 수 있을 것이라 생각했음.
그러나 재귀함수로 이를 해결하는 코드를 짜는것이 어려웠음.

stack이나 재귀나 근본적으로 같은 구조이지만 여기서는 stack으로 해결하는 것이 더 쉬운 방법이었다.

주어진 문자열을 순회하면서 stack top에 들어있는 폭탄의 인덱스와 비교해주며 폭탄이 연결되는지 확인
- 만약 연결되거나 폭탄의 첫번째 문자라면 stack에 넣어준다.
- 만약 연결되지 않으면 스택에 들어있는 문자를 역으로 출력해주고 스택을 비워준다.
- stack top에 m(문자열 폭탄의 크기)번째 문자가 들어있으면 그 만큼 pop해주면 됨.

## 복기
재귀를 활용해서 풀려다가 시간 많이 잡아먹음.

 스택 이용안하고도 풀 수 있음 : https://www.acmicpc.net/source/50004320
-> 포인터를 두개 둔다. 문자열을 순회하면서 앞에 있는(이미 지나쳐온 문자들) m개의 문자열이 폭탄인지 확인, 후에 만약 폭탄이라면 인덱스를 폭탄 사이즈 만큼 빼준다. 그리고 나머지 포인터는 계속 뒤에있는 문자열을 가르키게 해서 해당 문자열을 터진 문자열에 덮어쓰면서 검사해나가면 됨
-> 이러면 문자열을 삭제해 나가는 것과 같은 원리

**+++ 100만 정도 되는 사이즈의 문자열을 출력할때 문자 하나하나 출력하는 것보다, `for(int i=0;i<n;i++) cout<<str[i];`
 문자열 하나를 한번에 (string)으로 출력하는 것이 훨씬 빠르다. `cout<<str[i];`**

<img width="211" alt="스크린샷 2024-03-18 오후 10 11 12" src="https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/55823958/516a5d15-0928-4a31-b87a-eeb29548daf1">

4배나 차이나더라..


