### PR TITLE
1027 고층 건물

### DIFF
--- a/김남주/1027_고층건물.cpp
+++ b/김남주/1027_고층건물.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(0)
+#define read_input freopen("input.txt","r",stdin);
+using namespace std;
+#define FOR(i, n) for (int i=0;i<(n);i++)
+
+int n;
+double h[50];
+double grad[50][50];
+
+
+inline int abs(int x) {return x<0?-x:x;}
+bool chk(int s, int e) {
+    grad[s][e]=(h[e]-h[s])/(e-s);
+    for (int i=s+1;i<=e-1;i++) {
+        if (grad[s][e]<=grad[s][i]) return false;
+    }
+    return true;
+}
+int num[50];
+
+int main() {
+    fastio;
+    cin>>n;
+    FOR(i, n) cin>>h[i];
+    FOR(i, n) {
+        for (int j=i+1;j<n;j++) {
+            if (chk(i,j)) {
+                ++num[i];
+                ++num[j];
+            }
+        }
+    }
+    int ans=0;
+    FOR(i, n) ans=max(ans,num[i]);
+    cout<<ans;
+}


### PR DESCRIPTION
## 복기
건물 A에서 건물 B를 볼 수 있다 <-> 건물 B에서 건물 A를 볼 수 있다.

따라서 num[N] 의 배열을 선언하고 
```
for (int i=0;i<n;i++) {
    for (int j=i+1;j<n;j++) {
        if (건물 i에서 건물 j를 볼 수 있는가?) { num[i]++; num[j]++; }
}
```
의 방식으로 풀려고 생각함

'건물 i에서 건물 j를 볼 수 있는가'는 건물 i에서 건물 j를 이은 선분의 기울기를 구하고 i+1부터 J-1건물까지 순회하면서 h[i]부터 구한 기울기를 더해주면서 해당 값이 순회하고 있는 건물의 높이 보다 높으면 볼 수 있는것이고, 낮다면 볼 수 없는것

시간복잡도를 따졌을 때, 두 반복문 O(N^2), 그리고 건물 I,j 의 볼 수 있는지 여부 O(N)이어서 O(N^3)임.
N은 최대 50이므로 시간안에 충분히 들어온다.

## 복기

그런데 위 풀이가 틀렸는데, 이는 double의 정밀도 때문이었을 것이라 생각.
i, j 건물의 기울기는 double로 구하게 되고 이 값은 실제 값과 오차가 있다.
그런데 순회하면서 이 값을 계속 더해나가니 오차가 누적돼서 틀리는 경우가 나왔던 것임.

따라서 이를 해결하기 위해 기울기를 더해나가면 안된다고 생각해서 다른 풀이를 생각함 
-> 건물 i와 k의 기울기 < 건물 i와 j의 기울기 를 만족하면 됨 ( i+1 <= k <= j - 1)
따라서 기울기를 더해나갈 필요 없이 각 건물 간의 기울기를 계산한 다음에 순회하면서 대소비교만 해주면 된다.