### PR TITLE
2179 비슷한 단어

### DIFF
--- a/김남주/2179_비슷한단어.cpp
+++ b/김남주/2179_비슷한단어.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+#include <algorithm>
+#include <string>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(0)
+#define read_input freopen("input.txt","r",stdin);
+using namespace std;
+
+struct e {
+    string s;
+    int idx;
+};
+int n;
+e a[20000];
+int f(string& a, string& b) {
+    int res=0;
+    int sz=min(a.size(),b.size());
+    for (int i=0;i<sz;i++) {
+        if (a[i]!=b[i])return res;
+        res++;
+    }
+    return res;
+}
+int main() {
+    fastio;
+    cin>>n;
+    string tmp;
+    for (int i=0;i<n;i++) {
+        cin>>tmp;
+        a[i]={tmp,i};
+    }
+    sort(a, a+n,[](const e& x, const e& y){
+            return x.s<y.s;
+            });
+    int ans=0;
+    int s,t=n+1;
+    string sstr,tstr;
+    for (int i=0;i<n;i++) {
+        int pi=0;
+        for (int j=i+1;j<n;j++) {
+           int x=f(a[i].s,a[j].s);
+           if (x<pi) break; 
+           pi=x;
+           if (x>ans) {
+               ans=x;
+               int ct=a[i].idx, cs=a[j].idx;
+               string ctstr=a[i].s,csstr=a[j].s;
+               if (cs>ct) swap(cs,ct),swap(ctstr,csstr);
+               s=cs,t=ct,sstr=csstr,tstr=ctstr;
+           } else if (x==ans) {
+               int ct=a[i].idx, cs=a[j].idx;
+               string ctstr=a[i].s,csstr=a[j].s;
+               if (cs>ct) swap(cs,ct),swap(ctstr,csstr);
+               if (cs<s ||(cs==s && ct<t)) {
+                   s=cs,t=ct;
+                   sstr=csstr,tstr=ctstr;
+               }
+           }
+        }
+    }
+    cout<<sstr<<'\n'<<tstr;
+}


### PR DESCRIPTION
## 사고 흐름
접두사가 가장 많이 겹치는 서로 다른 두 단어 찾기
입력에 주어진 순서대로 풀려면 N^2이 걸린다 근데 문자열의 길이가 각 최대 100이므로 시간 초과

따라서 문자열 사전순으로 정렬해준다. (문제 조건에 비슷한 단어가 여러개일 경우에는 입력 순서를 고려해야 하므로 이 입력순서가 저장되어 있을 수 있게끔  배열의 요소에 문자열 뿐만 아니라 인덱스도 넣어 준다.)
-> 비슷한 단어끼리 모여있게 됨
따라서 여기서 이중 for문을 돌아준다.  
안쪽 for문에서 이전 겹치는 개수보다 낮아지면 안에 있는 for문을 break
겹치는 개수가 현재 답보다 많아지면 갱신해주고 만약 같으면 입력순서에 따라 갱신

## 복기
이 점을 놓치고 있었는데 **문자열 사전순으로 정렬하면 가장 비슷한 단어는 바로 자신의 옆단어** 이므로 이중 for문 코드를 작성할 필요가 없다.
(사실 내가 짠 코드도 이전의 겹치는 값보다 작아지면 break하게끔 해놔서 사실상 하나의 for문을 도는 것과 같다.)