### PR TITLE
14658 하늘에서 별똥별이 빗발친다

### DIFF
--- a/김남주/14658_하늘에서별똥별이빗발친다.cpp
+++ b/김남주/14658_하늘에서별똥별이빗발친다.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+#include <algorithm>
+#include <cstring>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(0)
+#define read_input freopen("input.txt","r",stdin);
+using namespace std;
+struct E {int x,y;};
+int n,m,l,k;
+int dy[4]{1,1,-1,-1},dx[4]{-1,1,-1,1};
+E pos[100];
+int main() {
+    fastio;
+    cin>>n>>m>>l>>k;
+    for (int i=0;i<k;i++) cin>>pos[i].x>>pos[i].y;
+    int ans=0;
+    for (int i=0;i<k;i++) {
+        for (int j=0;j<k;j++) {
+            int x1=pos[i].x,y1=pos[j].y;
+            int x2=x1+l,y2=y1+l;
+            int cur=0;
+            for (int j=0;j<k;j++) if (pos[j].x>=x1 && pos[j].x<=x2 && pos[j].y>=y1 && pos[j].y<=y2) cur++;
+            ans=max(ans,cur);
+            }
+    }
+    cout<<k-ans;
+}


### PR DESCRIPTION
## 사고흐름
정사각형이 주어진 점들을 최대로 얼마나 덮을 수 있는지 찾는 문제

먼저 탐색의 기준을 정사각형의 꼭짓점이 어디에 위치하는가로 설정했다.

가장 생각하기 쉬운 방법은 가능한 모든 좌표에 대해 탐색해보는 것, 그러나 최대 500,000이므로 시간안에 들어올 수 없다.

따라서 후보군을 좁혀야 한다. 
첫번째로 생각한 방법은 주어진 점이 정사각형의 꼭짓점이 되는 경우
테스트 케이스에 통과해서 제출했더니 틀렸음.
그래서 여러 예시를 그려본 결과 주어진 점이 꼭짓점이 되는 경우에 최대가 될 수 없는 반례를 찾음.

여러 예시를 그려본 결과 아래와 같이 주어진 두 점의 x,y 좌표 조합이 정사각형의 왼쪽 아래 꼭짓점이 되는 경우가 최대를 덮을 수 있는 후보라고 생각했음

<img src="https://github.com/SoraeCodingMasters/AlgorithmStudy/assets/55823958/30bb9520-c91f-4c32-a7a3-b17a48ea49bf" width="30%">

따라서 가능한 조합은 K x K개이고 각 조합마다 몇개의 별을 덮을 수 있는지 카운트 해야하므로 시간복잡도는 O(K^3)


## 복기
처음에는 왼쪽 아래 꼭짓점 뿐만 아니라 네 꼭짓점 모두 검사했었음.
(1,3), (2,5), (4,1), (5,2)같이 주어졌을때 왼쪽 아래만 검사하는게 애매해 보였음.

그러나 정사각형 자체가 대칭임을 생각해보면 4개중 하나의 꼭짓점만 검사해봐도 됨을 알 수 있다.
