### PR TITLE
22866 탑 보기

### DIFF
--- a/김남주/22866_탑보기.cpp
+++ b/김남주/22866_탑보기.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <vector>
+#include <stack>
+
+#define fastio cin.tie(0);cout.tie(0);ios::sync_with_stdio(0)
+#define read_input freopen("input.txt","r",stdin)
+
+using namespace std;
+#define MAX 100'000
+struct E {
+    int h, id;
+};
+int n, h[MAX], ans1[MAX], ans2[MAX];
+E stk[MAX];
+int sn=0;
+int main() {
+    fastio;
+    // read_input;
+    cin>>n;
+    for (int i=0;i<n;i++) {
+        cin>>h[i];
+        while (sn && stk[sn-1].h<=h[i]) sn--;
+        ans1[i]+=sn;
+        if (ans1[i] && sn) ans2[i]=stk[sn-1].id;
+        stk[sn++]={h[i],i+1};
+    }
+    sn=0;
+    for (int i=n-1;i>=0;i--) {
+        while (sn && stk[sn-1].h<=h[i]) sn--;
+        ans1[i]+=sn;
+        if (sn) {
+            if (!ans2[i]) ans2[i]=stk[sn-1].id;
+            else {
+                if ((i+1) - ans2[i] > stk[sn-1].id - (i+1)) ans2[i]=stk[sn-1].id;
+            }
+        }
+        stk[sn++]={h[i],i+1};
+    }
+    for (int i=0;i<n;i++) {
+        cout<<ans1[i];
+        if (ans1[i]) cout<<' '<<ans2[i];
+        cout<<'\n';
+    }
+}


### PR DESCRIPTION
## 사고 흐름
입력이 100,000 이므로 당연히 O(N^2)의 완전 탐색으로는 풀 수 없음

그렇다면 배열을 O(N)에 한번에 스캔하면서 볼 수 있는 건물을 체크해야 된다는 것.

문제의 중요한 조건은 바로 이것이었음 -> 자기 건물 보다 큰 건물만 볼 수 있고 뒤에 가려진 건물은 볼 수 없다.

이 조건을 보자마자 이전에 풀었던 #43 문제가 생각났고, 단조 스택으로 풀 수 있다고 생각했다.

차이점은 앞, 뒤로 볼 수 있는 것이기에 for 문을 두 번 돌렸어야 된다는 것.

즉, 앞에서 볼 수 있는 건물을 검사하는 for문 하나와 뒤에서 볼 수 있는 건물을 검사하는 for문 -> O(2N)으로 풀 수 있었다.


## 복기
스택은 큐와 다르게 배열로 쉽게 구현할 수 있다. (물론 큐도 원형큐로 잘 구현하면 됨)
STL에 구현되어 있는 스택을 사용하지 않고 정적으로 배열을 선언하고 이를 스택으로 사용하여 오버헤드를 줄이고 시간을 최소화 했다.